### PR TITLE
fix(wsl): automate profile detection and repair documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository serves as a robust, modular boilerplate for Bash configuration files, optimized for a modern development workflow. The setup is designed to be portable, maintainable, and strictly compliant with the XDG Base Directory Specification.
 
-![Screenshot](https://github.com/user-attachments/assets/34cfa27f-0d63-4ef5-8ba9-71be6aa0a7ae)
+![Screenshot](https://i.postimg.cc/FzqLSLXP/Screenshot.png)
 
 ## ✨ Features
 
@@ -45,7 +45,6 @@ To ensure you can manage your own configurations and sync them across your machi
         ./install.sh
         ```
 
-        > [!NOTE]
         > **Starship Installation**: The script prioritizes installing starship via your system's package manager. If your distribution is older (e.g., Debian 12, Ubuntu 24.04) and does not include Starship in its repositories, the script will automatically fallback to the official Starship installer script. No manual action is required.
 
     The script will:
@@ -86,12 +85,15 @@ This template uses a split-config approach for Git to separate personal and work
 1. **Primary Identity**: Edit `config/git/config` in your repo. Change the `[user]` section to your default Git profile.
 2. **Work Identity**: Edit `config/git/work`. This file is conditionally included.
 3. **Activation**: In `config/git/config`, update the path in `[includeIf "gitdir:~/workspace/"]` to match your work projects directory.
-    > [!IMPORTANT]
-    > Any git repository inside `~/workspace/` (or your chosen path) will automatically use the configuration defined in `config/git/work`.
+
+> [!IMPORTANT]
+> Any git repository inside `~/workspace/` (or your chosen path) will automatically use the configuration defined in `config/git/work`.
 
 ### WSL integration
 
-If you want to use applications that interact with the Windows PATH in WSL (e.g. VS Code, explorer.exe), but don't want WSL to access the entire Windows PATH, first add the following to `/etc/wsl.conf`:
+The script automatically detects if you are running inside WSL and attempts to retrieve your Windows User Profile path to enable integration with tools like VS Code (`code`).
+
+However, for this to work flawlessly while keeping your environment clean, it is recommended to disable the default Windows PATH appending in `/etc/wsl.conf` and allow Interop:
 
 ```toml
 [interop]
@@ -99,7 +101,8 @@ enabled = true
 appendWindowsPath = false
 ```
 
-Next, in `config/bash/rc.d/30-wsl.sh`, change `vscode_user_profile='/mnt/c/Users/Foo'` to your own Windows user path. Also, specify the Windows app alias and full application path you want to use using `alias`.
+> [!NOTE]
+> The `config/bash/rc.d/30-wsl.sh` script will explicitly add the necessary VS Code paths and aliases (like `explorer.exe`) only if Interop works, preventing errors if you have disabled it.
 
 ## 📦 Managing Your Dotfiles
 


### PR DESCRIPTION
## Summary
Automates Windows profile detection in WSL and fixes documentation syntax errors. This PR removes hardcoded paths for a zero-config WSL experience and ensures README alerts render correctly on GitHub.

## Key Changes
- **WSL**: Refactored `30-wsl.sh` to dynamically retrieve the Windows User Profile path via `cmd.exe`, eliminating manual configuration.
- **WSL**: Implemented an Interop availability check to strictly prevent execution of Windows binaries (e.g., `explorer.exe`) when WSL Interop is disabled.
- **Docs**: Corrected GitHub Flavored Markdown syntax for alerts (`[!NOTE]`, `[!IMPORTANT]`) to ensure proper rendering.
- **Docs**: Updated the screenshot URL and removed obsolete instructions regarding manual path editing.

## Verification
- **Case 1: Interop Enabled (Default)**
    - Run `source ~/.config/bash/rc.d/30-wsl.sh` inside WSL.
    - Verify that `explorer` opens Windows Explorer.
    - Verify that `code` (VS Code) path is correctly appended to `$PATH`.
- **Case 2: Interop Disabled (`/etc/wsl.conf`)**
    - Disable Interop and restart WSL.
    - Run `source ~/.config/bash/rc.d/30-wsl.sh`.
    - Verify that no errors occur and `explorer` alias is NOT created.