### PR TITLE
feat(git): enforce 'main' as default branch for new repositories

### DIFF
--- a/config/git/config.ini
+++ b/config/git/config.ini
@@ -13,6 +13,10 @@
     email = Foo@individual.com
     signingkey = AAAAAAAAAAAAAAAA
 
+[init]
+    # Use 'main' as the default branch name for new repositories
+    defaultBranch = main
+
 [core]
     # CACHE & PERFORMANCE
     # Use the cache for file status to speed up large monorepos
@@ -40,7 +44,7 @@
     verbose = true
 
 [tag]
-    # GPG sign commits by default ensures provenance
+    # GPG sign tags by default ensures provenance
     gpgSign = true
 
 [column]


### PR DESCRIPTION
## Summary
Updates the global Git configuration to explicitly set `main` as the default branch name for all newly initialized repositories. This ensures consistency across different environments and adheres to modern naming conventions, overriding any potential system defaults (which might still be `master` on older Git versions).

## Key Changes
- **Configuration Update**: Added `[init] defaultBranch = main` to `config/git/config.ini`.

## Impact
- **Workflow**: `git init` will now create a `main` branch by default instead of `master`.
- **Compatibility**: Requires Git 2.28+. (Note: The `install.sh` script already ensures a modern git version is installed, so compatibility is assured).

## Verification
- **Case 1: New Repository Initialization**
    - **Action**: Run `git init test_repo` followed by `cd test_repo && git status`.
    - **Result**: Output shows `On branch main`.