### PR TITLE
feat(install): add ripgrep to core toolchain

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -217,7 +217,7 @@ install_packages() {
 
     # Common utilities list.
     # Note: 'fzf' and 'starship' are handled separately via verify_and_install_tool.
-    local pkgs=(curl gawk git gnupg2 man-db vim zoxide)
+    local pkgs=(curl gawk git gnupg2 man-db ripgrep vim zoxide)
 
     # Append distro-specific packages
     if [ ${#DISTRO_PKGS[@]} -gt 0 ]; then


### PR DESCRIPTION
## Summary
Integrates `ripgrep` (a fast, line-oriented search tool) into the standard installation toolchain.

## Key Changes
- **Dependency Addition**: Added `ripgrep` to the `pkgs` array in `install_packages`.
- **Strategy**: Placed in the common package list rather than `DISTRO_PKGS` because the package name is consistent across all supported platforms (`apt`, `dnf`, `pacman`, `brew`), simplifying maintenance.

## Impact
- **Developer Experience**: The `rg` command is available immediately after installation.
- **Code Quality**: Keeps `detect_environment` clean by avoiding unnecessary conditionals for a universally named package.