### PR TITLE
feat(workflow): add AI human-in-the-loop git layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This repository serves as a robust, modular boilerplate for Bash configuration f
 - **Enhanced Shell Experience**: Powered by [ble.sh](https://github.com/akinomyoga/ble.sh) for syntax highlighting, auto-suggestions, and an advanced line editor with Vi mode.
 - **Fuzzy Search Everywhere**: [fzf](https://github.com/junegunn/fzf) integration for blazing-fast history search (Ctrl+R) and file finding.
 - **Smart Directory Navigation**: [zoxide](https://github.com/ajeetdsouza/zoxide) learns your habits, allowing you to jump to frequent directories with short commands.
-- **XDG Compliance**: Keeps your `$HOME` directory clean by storing configuration, data, and cache files in standard locations (`~/.config`, `~/.local/share`, etc.).
+- **XDG Compliance**: Keeps your `$HOME` directory clean by storing configuration, data, and cache files in standard locations (`~/.config`, `~/.local/share`, etc.). No `.vimrc`, no `~/.dsh` — even Vim, DeepSeek Harness, and the Hunk standalone fallback follow XDG (`$XDG_DATA_HOME/hunk`).
 - **Multi-Identity Git**: Easily manage work and personal Git profiles using conditional includes.
+- **Hardened Git**: `help.autocorrect = prompt`, double-lease safe force push (`git pf`), worktree-aware branch cleanup (`git bclean`), global hooks with `.local` chaining, GPG signing with TUI-friendly pinentry.
+- **AI Git Workflow (optional)**: A non-blocking Human-in-the-Loop flow — the agent drafts commit messages into `.git/AI_COMMIT_MSG`, the `prepare-commit-msg` hook injects them, and you review + GPG-sign. Review diffs in [Hunk](https://github.com/modem-dev/hunk) or [lazygit](https://github.com/jesseduffield/lazygit).
 - **Automated Setup**: A single script to install tools and set up configurations across different systems (supports Debian/Ubuntu, Fedora, Arch Linux, and macOS).
 
 ## 🚀 Installation
@@ -45,16 +47,35 @@ To ensure you can manage your own configurations and sync them across your machi
         ./install.sh
         ```
 
+        Optional flags:
+
+        | Flag | Installs |
+        | --- | --- |
+        | `--with-git-tui` | Git TUI tools: **hunk** (via pnpm, or official binary as fallback) + **lazygit** (package manager, release tarball as fallback) + their configs (`~/.config/hunk`, `~/.config/lazygit`) |
+        | `--with-dsh` | **DeepSeek Harness** via pnpm (`dsh` command) + symlinks the agent-agnostic `skills/` bundle (`git-commit-architect`, `git-pr-architect`) into `$DSH_HOME/skills` |
+
+        Flags are independent and combinable: `./install.sh --with-git-tui --with-dsh`.
+
         > **Starship Installation**: The script prioritizes installing starship via your system's package manager. If your distribution is older (e.g., Debian 12, Ubuntu 24.04) and does not include Starship in its repositories, the script will automatically fallback to the official Starship installer script. No manual action is required.
 
     The script will:
-    1. Install necessary dependencies (starship, fzf, zoxide, etc.) via your system's package manager.
+    1. Install necessary dependencies (starship, fzf, zoxide, gh, pinentry, pnpm, etc.) via your system's package manager and the pnpm standalone installer.
     2. Back up any existing configuration files to `~/dotfiles_backup_<timestamp>`.
     3. Create symlinks from `~/dotfiles` to the appropriate locations (mostly `~/.config/`).
 
 3. **Restart Shell**
 
     Open a new terminal window or run `source ~/.bashrc` to apply the changes.
+
+## ✅ Requirements
+
+- **Git >= 2.37** (config floors: `autoSetupRemote` 2.37, `zdiff3` 2.35, `autocorrect=prompt` 2.34, `branch --format` 2.31, `--force-if-includes` 2.30).
+- **GPG key** — `commit.gpgSign = true` requires a key. Replace the placeholder `[user] signingkey` in `config/git/config.ini` before your first commit, or every commit will fail.
+- **Distros**: Debian >= bookworm, Fedora, Arch Linux, macOS (Homebrew). Older distros may lack native `gh`/`lazygit` packages; the installer falls back to release tarballs.
+- **pnpm 12** is installed as a Node.js-free standalone binary, pinned to `12.0.0-rc.9` — the first pnpm shipped as a Rust-built standalone binary, so no Node.js needs to be pre-installed (override the pin with `PNPM_VERSION=<version> ./install.sh`). Node.js itself is provisioned on demand by pnpm (`pnpm runtime`, requires pnpm >= 11) only when the AI toolchain needs it — no system Node, no nvm.
+- **Vim >= 9.0** (optional) — commit messages wrap at 72 columns via `~/.config/vim/vimrc` (rewrapped automatically on save). An existing `~/.vimrc` takes precedence over that XDG path and would silently disable the wrapping — merge or remove it (the installer warns you).
+- **Default XDG paths** — the global `core.hooksPath` in `config/git/config.ini` points to `~/.config/git/hooks` (git resolves relative `hooksPath` values against the worktree, not the config file). If you set a custom `XDG_CONFIG_HOME`, the installer warns you and prints the exact `git config --global core.hooksPath "$XDG_CONFIG_HOME/git/hooks"` command to run; the `includeIf` work profile is XDG-aware and needs no adjustment.
+- **Login shell = Bash (recommended)** — this setup only activates under bash. macOS's system `/bin/bash` is 3.2 (frozen under GPLv3) while ble.sh recommends Bash >= 4.0 (`auto-complete`/`menu-filter` need 4.0+): on macOS the installer installs the current Homebrew `bash` (5.x) and **automatically switches your login shell when it is the system `/bin/bash`**; if your login shell is zsh/fish or the switch fails, the installer's final message shows the one-time manual steps. On Linux no automatic switch is ever performed — but if your login shell is not bash, the same final-message guidance appears (`sudo chsh -s "$(command -v bash)" ...`).
 
 ## 🔧 Customization
 
@@ -82,12 +103,65 @@ Then, run `./install.sh` again to ensure symlinks are correct (though for `rc.d`
 
 This template uses a split-config approach for Git to separate personal and work identities.
 
-1. **Primary Identity**: Edit `config/git/config.ini` in your repo. Change the `[user]` section to your default Git profile.
-2. **Work Identity**: Edit `config/git/work.ini`. This file is conditionally included.
-3. **Activation**: In `config/git/config.ini`, update the path in `[includeIf "gitdir:~/workspace/"]` to match your work projects directory.
+Both `[user]` blocks ship with **empty values on purpose**: until you fill them in, `git commit` is refused with a clear `empty ident` error — no commits can silently happen under a placeholder name.
+
+1. **Primary (personal) identity** — edit the `[user]` section of `config/git/config.ini` (or run the equivalent `git config --global` commands):
+
+   ```sh
+   git config --global user.name "Your Name"
+   git config --global user.email "you@example.com"
+   gpg --full-generate-key                      # generate a key once
+   git config --global user.signingkey <GPG fingerprint>
+   ```
+
+2. **Work identity** — fill in `config/git/work.ini` (created next to `config.ini`, i.e. `$XDG_CONFIG_HOME/git/work.ini`) with your company details:
+
+   ```ini
+   [user]
+       name = Company Name
+       email = you@company.com
+       signingkey = <GPG fingerprint>
+   ```
+
+3. **Activation** — in `config/git/config.ini`, update the path in `[includeIf "gitdir:~/workspace/"]` to match your work projects directory.
 
 > [!IMPORTANT]
-> Any git repository inside `~/workspace/` (or your chosen path) will automatically use the configuration defined in `config/git/work.ini`.
+> Any git repository inside `~/workspace/` (or your chosen path) will automatically use the configuration defined in `config/git/work.ini`. These are also empty until you fill them in — same refuse-to-commit behavior.
+
+> [!TIP]
+> To make GitHub trust your commits, export the public key: `gpg --armor --export <GPG fingerprint>` → GitHub → Settings → SSH and GPG keys → New GPG key.
+
+### The AI Git Workflow (optional layer)
+
+The workflow is split into two layers:
+
+- **Core (always installed)**: hardened git config, global hooks
+  (`prepare-commit-msg` AI-draft injection + `.local` dispatchers), 72-column
+  commit wrapping (Vim `gitcommit`), TUI-friendly GPG pinentry. Everything is
+  inert by default: without an agent writing `.git/AI_COMMIT_MSG` and without
+  repo-local `.local` hooks, nothing changes behavior.
+- **Optional flags**: `--with-git-tui` (hunk + lazygit Git TUI tools) and
+  `--with-dsh` (DeepSeek Harness + skill symlink). The skill itself lives at
+  the repo-root `skills/` and is agent-agnostic — any agent tool can read it.
+
+See [docs/git-guide.md](docs/git-guide.md) (configuration reference) and
+[docs/github-flow.md](docs/github-flow.md) (step-by-step workflow, including
+the AI-assisted HITL flow).
+
+### DeepSeek Harness home
+
+The dotfiles relocate DSH's config root from `~/.dsh` to `$DSH_HOME`
+(`~/.local/share/dsh`, exported by `config/bash/rc.d/00-xdg.sh`). If you have
+an existing `~/.dsh`, migrate it once:
+
+```sh
+mkdir -p ~/.local/share/dsh && mv ~/.dsh/* ~/.local/share/dsh/
+```
+
+> [!NOTE]
+> `DSH_HOME` is an environment variable — DSH launched from a shell picks it
+> up automatically; desktop launchers that bypass the shell fall back to
+> `~/.dsh`.
 
 ### WSL integration
 

--- a/config/bash/rc.d/10-env.sh
+++ b/config/bash/rc.d/10-env.sh
@@ -27,6 +27,19 @@ export LESS_TERMCAP_so=$'\e[1;44;33m'  # Begins standout-mode
 export LESS_TERMCAP_ue=$'\e[0m'        # Ends underline
 export LESS_TERMCAP_us=$'\e[1;32m'     # Begins underline
 
+# pnpm global directory (Node.js-free standalone binary; installed by
+# install.sh into $XDG_DATA_HOME/pnpm). pnpm 12 keeps its binaries under
+# $PNPM_HOME/bin (pnpm itself, node/npm provisioned via `pnpm runtime`,
+# and all globally installed CLIs). See https://pnpm.io/installation.
+export PNPM_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/pnpm"
+# Prepend pnpm's bin directory to PATH if it exists
+if [[ -d "$PNPM_HOME/bin" && ":$PATH:" != *":$PNPM_HOME/bin:"* ]]; then
+    export PATH="$PNPM_HOME/bin:$PATH"
+fi
+
+# DeepSeek Harness config root (user skills live in $DSH_HOME/skills).
+# Keeps ~/.dsh out of the home directory; DSH resolves $DSH_HOME first.
+export DSH_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/dsh"
 
 # ----------------------------------------------------------------------
 # USER CUSTOMIZATIONS

--- a/config/bash/rc.d/50-ble.sh
+++ b/config/bash/rc.d/50-ble.sh
@@ -4,6 +4,15 @@
 # Disable ble.sh in VSCode to prevent multiline hanging issues.
 [[ "$TERM_PROGRAM" == *vscode* ]] && return 0
 
+# ble.sh recommends Bash >= 4.0 — auto-complete and menu-filter are 4.0+
+# features. macOS's system bash is 3.2 (frozen under GPLv3); install.sh
+# installs the Homebrew bash and switches the login shell, but sessions that
+# were already open (or explicit `/bin/bash` invocations) still run 3.2.
+# Say so clearly instead of silently degrading.
+if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
+    printf 'Warning: Bash %s (< 4.0) — ble.sh auto-complete/menu-filter are unavailable; use Bash >= 4.0 (see README, install.sh handles it).\n' "${BASH_VERSION:-unknown}" >&2
+fi
+
 # --- Installation ---
 BLESH_DIR="$XDG_DATA_HOME/blesh"
 BLESH_INSTALLED_PATH="$BLESH_DIR/ble.sh"

--- a/config/bash/rc.d/90-completions.sh
+++ b/config/bash/rc.d/90-completions.sh
@@ -46,6 +46,9 @@ generate_completion_if_missing() {
 
 # --- Static Completions (Generated Once) ---
 
+# pnpm (Node.js-free standalone install; see install.sh)
+generate_completion_if_missing "pnpm" "pnpm completion bash"
+
 # Example: Rust Toolchain
 generate_completion_if_missing "rustup" "rustup completions bash"
 generate_completion_if_missing "cargo" "rustup completions bash cargo"

--- a/config/git/config.ini
+++ b/config/git/config.ini
@@ -8,10 +8,12 @@
     # Enforce explicit configuration to prevent committing as system user
     useConfigOnly = true
 
-    # Default identity (Overridden by includeIf for specific directories)
-    name = Foo
-    email = Foo@individual.com
-    signingkey = AAAAAAAAAAAAAAAA
+    # Default identity — left EMPTY on purpose: git refuses to commit with a
+    # clear error until you fill these in (see README "Git Identity Setup").
+    # Enter your GPG key fingerprint last (gpg --full-generate-key).
+    name =
+    email =
+    signingkey =
 
 [init]
     # Use 'main' as the default branch name for new repositories
@@ -35,6 +37,11 @@
     # EDITOR
     # External editor config (Force yourself to write good commit messages)
     editor = vim
+
+    # Global hooks directory (XDG-compliant, symlinked by install.sh).
+    # NOTE: Overrides .git/hooks. Dispatched via *.local files for 
+    # prepare-commit-msg (AI draft), pre-commit, commit-msg, pre-push, and post-commit.
+    hooksPath = ~/.config/git/hooks
 
 [commit]
     # GPG sign commits by default ensures provenance
@@ -83,7 +90,7 @@
     # Clean up stale remote-tracking branches
     prune = true
     pruneTags = true
-    # Auto-detect CPU cores for parallel fetching
+    # Let Git choose a reasonable default for parallel fetching
     parallel = 0
 
 [push]
@@ -108,8 +115,9 @@
     enabled = true
 
 [help]
-    # Auto-execute typos after 1 second (e.g., 'git sttaus' -> 'git status')
-    autocorrect = 10
+    # Never auto-execute typos. Always prompt for explicit confirmation
+    # before running the corrected command (e.g., 'git sttaus' -> 'git status').
+    autocorrect = prompt
 
 [alias]
     # --- Efficiency Shortcuts ---
@@ -121,9 +129,11 @@
     sw = switch
     rs = restore
 
-    # Cleanup Branch: Deletes all branches merged into current HEAD (or specified branch)
-    # Excludes main, master, and the current checked-out branch.
-    bclean = "!f() { git branch --merged ${1-HEAD} | grep -vE 'main|master|\\*' | xargs -r git branch -d; }; f"
+    # bclean: Deletes branches merged into <ref> (default: HEAD).
+    # - Safe delete (-d) only; skips protected (main/master/develop/staging/trunk),
+    #   current HEAD, and other worktrees.
+    # - NOTE: Squash-merges not detected (use `gh pr merge --delete-branch` instead).
+    bclean = "!f() { TARGET_REF=\"${1:-HEAD}\"; git branch --format='%(HEAD)|%(worktreepath)|%(refname:short)' | while IFS='|' read -r head wt branch; do [ \"$head\" = '*' ] || [ -n \"$wt\" ] && continue; [ \"$branch\" = \"$TARGET_REF\" ] && continue; echo \"$branch\" | grep -qE '^(main|master|develop|staging|trunk)$' && continue; git merge-base --is-ancestor \"$branch\" \"$TARGET_REF\" 2>/dev/null && git branch -d \"$branch\"; done; }; f"
 
     # --- Log Visualization ---
 
@@ -147,6 +157,11 @@
     # Diff excluding whitespace changes
     dw = diff -w
 
+    # Diff through Hunk's pager when hunk is on PATH (part of the optional
+    # Git TUI toolchain installed via './install.sh --with-git-tui'); falls
+    # back to a plain diff when hunk is missing (no hard error).
+    hdiff = "!f() { if command -v hunk >/dev/null 2>&1; then git -c core.pager='hunk pager' diff \"$@\"; else git diff \"$@\"; fi; }; f"
+
     # --- Rebase & Sync ---
 
     # Rebase interactive on last N commits
@@ -161,8 +176,12 @@
     # Update: Pull with rebase
     up = pull --rebase
 
-    # Safe force push (Protection against overwriting others work)
-    pf = push --force-with-lease
+    # Safe force push: double-lease verification.
+    # --force-with-lease checks the remote-tracking ref; --force-if-includes
+    # additionally checks the local reflog to ensure the remote tip is already
+    # integrated locally. Prevents overwriting others' work even after a
+    # background fetch. Requires Git >= 2.30.
+    pf = push --force-with-lease --force-if-includes
 
     # --- Maintenance ---
 
@@ -173,14 +192,21 @@
 # This is a modern way to manage multiple work/personal identities.
 #
 # Usage:
-# 1. Create a `~/.config/git/work.ini` file to store only company user information.
+# 1. Create a `work.ini` file next to this one (i.e.
+#    $XDG_CONFIG_HOME/git/work.ini) and FILL IN your company identity
+#    (ships empty on purpose — see README "Git Identity Setup"):
 #    [user]
-#        name = Company Foo
-#        email = foo@company.com
-#        signingkey = BBBBBBBBBBBBBBB
+#        name = Your Company Name
+#        email = you@company.com
+#        signingkey = <GPG fingerprint>
 #
 # 2. In the following settings, change `~/workspace/` to the directory path where you store your company projects.
 #    Git will automatically load and overwrite the corresponding user settings when entering the directory.
+#
+# NOTE: the include path below is RELATIVE on purpose — git resolves relative
+# include paths against the directory of the config file containing the
+# directive, so work.ini is found wherever THIS config.ini lives (default
+# ~/.config/git or any custom XDG_CONFIG_HOME).
 
 [includeIf "gitdir:~/workspace/"]
-    path = ~/.config/git/work.ini
+    path = work.ini

--- a/config/git/hooks/commit-msg
+++ b/config/git/hooks/commit-msg
@@ -1,0 +1,18 @@
+#!/bin/sh
+# ==============================================================================
+# Global commit-msg Dispatcher
+# Path: ~/.config/git/hooks/commit-msg
+# Description: core.hooksPath redirects ALL hooks to this global directory,
+#              which would silently disable repository-local hooks. This
+#              dispatcher restores them: a repo hook stored as
+#              .git/hooks/commit-msg.local (executable) is chained transparently.
+# ==============================================================================
+
+HOOK_NAME="$(basename "$0")"
+LOCAL_HOOK="$(git rev-parse --git-dir)/hooks/${HOOK_NAME}.local"
+
+if [ -x "$LOCAL_HOOK" ]; then
+    exec "$LOCAL_HOOK" "$@"
+fi
+
+exit 0

--- a/config/git/hooks/post-commit
+++ b/config/git/hooks/post-commit
@@ -1,0 +1,28 @@
+#!/bin/sh
+# ==============================================================================
+# Global post-commit Dispatcher
+# Path: ~/.config/git/hooks/post-commit
+# Description: core.hooksPath redirects ALL hooks to this global directory,
+#              which would silently disable repository-local hooks. This
+#              dispatcher restores them: a repo hook stored as
+#              .git/hooks/post-commit.local (executable) is chained transparently.
+#              Also implements the AI draft lifecycle: .git/AI_COMMIT_MSG is
+#              removed after the FIRST successful commit (any source, incl.
+#              -m/amend) — failed commits (editor abort, GPG signing error)
+#              keep the draft so the human can retry without re-asking the
+#              agent. Per-worktree safe: the worktree's own gitdir is used.
+# ==============================================================================
+
+HOOK_NAME="$(basename "$0")"
+GIT_DIR="$(git rev-parse --git-dir)"
+LOCAL_HOOK="${GIT_DIR}/hooks/${HOOK_NAME}.local"
+
+# AI draft lifecycle: successful commit -> buffer is stale, remove it.
+AI_MSG_FILE="${GIT_DIR}/AI_COMMIT_MSG"
+[ -f "$AI_MSG_FILE" ] && rm -f "$AI_MSG_FILE"
+
+if [ -x "$LOCAL_HOOK" ]; then
+    exec "$LOCAL_HOOK" "$@"
+fi
+
+exit 0

--- a/config/git/hooks/pre-commit
+++ b/config/git/hooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+# ==============================================================================
+# Global pre-commit Dispatcher
+# Path: ~/.config/git/hooks/pre-commit
+# Description: core.hooksPath redirects ALL hooks to this global directory,
+#              which would silently disable repository-local hooks. This
+#              dispatcher restores them: a repo hook stored as
+#              .git/hooks/pre-commit.local (executable) is chained transparently.
+# ==============================================================================
+
+HOOK_NAME="$(basename "$0")"
+LOCAL_HOOK="$(git rev-parse --git-dir)/hooks/${HOOK_NAME}.local"
+
+if [ -x "$LOCAL_HOOK" ]; then
+    exec "$LOCAL_HOOK" "$@"
+fi
+
+exit 0

--- a/config/git/hooks/pre-push
+++ b/config/git/hooks/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+# ==============================================================================
+# Global pre-push Dispatcher
+# Path: ~/.config/git/hooks/pre-push
+# Description: core.hooksPath redirects ALL hooks to this global directory,
+#              which would silently disable repository-local hooks. This
+#              dispatcher restores them: a repo hook stored as
+#              .git/hooks/pre-push.local (executable) is chained transparently.
+#              (Stdin with the remote ref list is passed through via exec.)
+# ==============================================================================
+
+HOOK_NAME="$(basename "$0")"
+LOCAL_HOOK="$(git rev-parse --git-dir)/hooks/${HOOK_NAME}.local"
+
+if [ -x "$LOCAL_HOOK" ]; then
+    exec "$LOCAL_HOOK" "$@"
+fi
+
+exit 0

--- a/config/git/hooks/prepare-commit-msg
+++ b/config/git/hooks/prepare-commit-msg
@@ -1,0 +1,55 @@
+#!/bin/sh
+# ==============================================================================
+# Global prepare-commit-msg Hook
+# Path: ~/.config/git/hooks/prepare-commit-msg
+# Description: Injects an AI-generated commit message draft
+#              (.git/AI_COMMIT_MSG, written by an AI agent working in
+#              draft-only mode) into the commit editor buffer, then chains
+#              the repository-local hook at .git/hooks/prepare-commit-msg.local
+#              if present.
+#
+# Behavior:
+#   - Injection happens ONLY for plain `git commit` (no -m/-t/-F source,
+#     no merge/amend): a human still reviews and edits the message in $EDITOR.
+#   - The draft buffer is NOT deleted here: it survives an editor abort / GPG
+#     signing failure, and is removed by the global post-commit dispatcher
+#     after a successful commit (any source, incl. -m/amend - which also
+#     prevents stale drafts from leaking into later commits).
+#   - Per-worktree safe: $(git rev-parse --git-dir) resolves to the worktree's
+#     own gitdir, so each worktree has an independent AI_COMMIT_MSG buffer.
+# ==============================================================================
+set -e
+
+COMMIT_MSG_FILE="$1"
+COMMIT_SOURCE="$2"
+SHA1="$3"
+
+GIT_DIR="$(git rev-parse --git-dir)"
+AI_MSG_FILE="${GIT_DIR}/AI_COMMIT_MSG"
+
+# Inject the AI draft only for plain `git commit` (empty source).
+# The draft is wrapped to <= 72 columns AT INJECTION (fold -s -w 72:
+# word-boundary, line-by-line, bullets/structure preserved), so the editor
+# always opens a wrapped draft regardless of the user's vim/editor config.
+# The vimrc BufWritePre rewrap remains as a second line of defense for
+# hand edits made during review.
+if [ -z "$COMMIT_SOURCE" ] && [ -f "$AI_MSG_FILE" ] && [ -s "$AI_MSG_FILE" ]; then
+    TEMP_FILE="$(mktemp)"
+
+    fold -s -w 72 "$AI_MSG_FILE" > "$TEMP_FILE"
+    printf '\n' >> "$TEMP_FILE"
+    cat "$COMMIT_MSG_FILE" >> "$TEMP_FILE"
+
+    mv "$TEMP_FILE" "$COMMIT_MSG_FILE"
+fi
+
+# Chain the repository-local hook (if any) for backwards compatibility.
+# exec runs the hook as this process (direct argv execve - no shell string
+# interpretation, same trust boundary as a plain call) so the hook's exit
+# status reaches git unchanged. The AI draft is kept until post-commit.
+LOCAL_HOOK="${GIT_DIR}/hooks/prepare-commit-msg.local"
+if [ -x "$LOCAL_HOOK" ]; then
+    exec "$LOCAL_HOOK" "$COMMIT_MSG_FILE" "$COMMIT_SOURCE" "$SHA1"
+fi
+
+exit 0

--- a/config/git/work.ini
+++ b/config/git/work.ini
@@ -1,4 +1,6 @@
+# Work identity — fill in your company details (see README "Git Identity Setup").
+# Left EMPTY on purpose: git refuses commits in ~/workspace until configured.
 [user]
-    name = Company Foo
-    email = Foo@company.com
-    signingkey = BBBBBBBBBBBBBBB
+    name =
+    email =
+    signingkey =

--- a/config/hunk/config.toml
+++ b/config/hunk/config.toml
@@ -1,0 +1,11 @@
+# =============================================
+# Hunk Config
+# Path: ~/.config/hunk/config.toml
+# Part of the optional AI review toolchain
+# (installed via './install.sh --with-git-tui')
+# =============================================
+
+theme = "auto"
+mode = "auto"
+exclude_untracked = false
+agent_notes = true

--- a/config/lazygit/config.yml
+++ b/config/lazygit/config.yml
@@ -1,0 +1,46 @@
+# =============================================
+# Lazygit Integration Config for the AI HITL Flow
+# Path: ~/.config/lazygit/config.yml
+# Part of the optional AI review toolchain
+# (installed via './install.sh --with-git-tui')
+# =============================================
+
+gui:
+  showIcons: true
+  theme:
+    activeBorderColor:
+      - '#50fa7b'
+      - bold
+    inactiveBorderColor:
+      - '#6272a4'
+
+# NOTE: git.paging.pager is intentionally NOT set. The interactive Hunk TUI
+# is launched via the 'H' custom command below (subprocess), which is more
+# reliable than piping diffs into an interactive pager.
+
+customCommands:
+  - key: 'H'
+    context: 'files'
+    command: 'hunk diff'
+    description: 'Launch Hunk TUI review of the working tree'
+    subprocess: true
+
+  # 'A' is bound to git commit with the AI draft injected by the
+  # prepare-commit-msg hook. Context is 'files' (not 'global') on purpose:
+  # lazygit's built-in 'A' = Amend in the commits/stash panels must keep
+  # working; in the Files panel 'A' is unbound, so no collision.
+  - key: 'A'
+    context: 'files'
+    command: 'git commit'
+    description: 'Commit with AI draft injected by the prepare-commit-msg hook'
+    subprocess: true
+
+  # Safe force push (--force-with-lease --force-if-includes). NOT bound to 'P':
+  # lazygit's default keymap is P = Push, p = Pull (>= 0.44, see Config.md
+  # 'pushFiles: P / pullFiles: p'), so overriding 'P' would silently replace
+  # the normal push. 'F' is verified unbound across the default keymap.
+  - key: 'F'
+    context: 'global'
+    command: 'git pf'
+    description: 'Safe force push (--force-with-lease --force-if-includes)'
+    subprocess: true

--- a/config/vim/vimrc
+++ b/config/vim/vimrc
@@ -1,0 +1,33 @@
+" =============================================
+" Minimal Vim Config
+" Path: ~/.config/vim/vimrc (symlinked from config/vim; Vim >= 9.0
+"       loads this XDG path natively when ~/.vimrc does not exist)
+" Purpose: deterministic commit-message wrapping at 72 columns.
+" Git sets the filetype to 'gitcommit' when editing commit messages
+" (including prepare-commit-msg injected drafts), so this applies ONLY
+" to commit messages — all other files are unaffected.
+" =============================================
+
+" Wrap commit message lines at 72 columns while typing
+autocmd FileType gitcommit setlocal textwidth=72
+
+" Visually mark the 73rd column (the wrap limit + 1) in commit messages
+autocmd FileType gitcommit setlocal colorcolumn=73
+
+" Rewrap long commit-message lines deterministically ON SAVE.
+" textwidth only wraps text that is being typed — lines written by an AI
+" draft (agent-authored, injected via the prepare-commit-msg hook) are NOT
+" rewrapped by Vim on their own, so fix them here.
+" Two separate defs (a pipe inside an :autocmd definition would truncate it):
+" first trims trailing whitespace, second rewraps. Only non-comment (#) lines
+" are filtered: git's template hint lines and the `git commit -v` diff listing
+" stay untouched. `fold -s -w 72` breaks at word boundaries one line at a
+" time, preserving bullet/paragraph structure — a `gq` paragraph join would
+" merge list items into prose. Idempotent: already-wrapped lines pass through
+" unchanged. Requires the BSD/GNU `fold` utility (present on macOS and all
+" supported Linux distros). Note: `fold -w` counts BYTES (not display
+" columns), so a CJK line wraps at 72 bytes ≈ 24 full-width characters.
+" Commit messages in this project are English-first (see the
+" git-commit-architect skill), so this rarely matters.
+autocmd BufWritePre COMMIT_EDITMSG silent! keepjumps %s/\s\+$/e
+autocmd BufWritePre COMMIT_EDITMSG silent! keepjumps global/^[^#]/execute '.!fold -s -w 72'

--- a/docs/git-guide.md
+++ b/docs/git-guide.md
@@ -1,69 +1,169 @@
 # Strict Git Workflow Guide
 
-This document outlines the required Git configuration and workflow patterns for contributing to this project. We enforce a linear history and strict commit discipline to ensure the repository remains maintainable and bisect-friendly.
+This document outlines the required Git configuration and workflow patterns for
+this project. We enforce a linear history, strict commit discipline, and
+cryptographic signing to keep the repository maintainable and bisect-friendly.
+
+## 0. Requirements
+
+- **Git >= 2.37** — the shipped config relies on features with these floors:
+  - `push.autoSetupRemote` (2.37), `merge.conflictstyle=zdiff3` (2.35),
+    `help.autocorrect=prompt` (2.34), `git branch --format` (2.31),
+    `push --force-if-includes` (2.30).
+- **GPG key** — `commit.gpgSign = true` means every commit must be signed.
+  Generate a key (`gpg --full-generate-key`) and put its fingerprint into
+  `config/git/config.ini` (`[user] signingkey`) **before** your first commit;
+  the template's placeholder key will fail otherwise.
+- **Vim >= 9.0** (optional but recommended) — `~/.config/vim/vimrc` wraps
+  commit messages at 72 columns via the `gitcommit` filetype.
 
 ## 1. Core Principles
 
-- **Atomic Commits**: Each commit must do one thing and one thing only. Do not mix refactoring with feature additions.
-- **Linear History**: We do not use merge commits for feature branches. We `rebase`.
+- **Atomic Commits**: Each commit must do one thing and one thing only. Do not
+  mix refactoring with feature additions.
+- **Linear History**: We do not use merge commits for feature branches. We
+  `rebase`.
 - **Signed Commits**: All commits must be GPG signed to verify authorship.
 
 ## 2. Configuration Overview
 
-The project includes a hardened `config/git/config.ini` designed to enforce these principles. Key features include:
+The project includes a hardened `config/git/config.ini`. Key features:
 
-- **Autocrlf Input**: Forces LF line endings in the repository to prevent cross-platform whitespace noise.
-- **GPG Signing**: `gpgSign = true` is enabled by default for both commits and tags.
-- **Histogram Diff**: Uses a superior algorithm for calculating diffs, which is more aware of code structure than the default Myers algorithm.
-- **Rebase on Pull**: `pull.rebase = true` prevents accidental merge bubbles when pulling upstream changes.
+- **Never auto-execute typos**: `help.autocorrect = prompt` (Git >= 2.34)
+  requires explicit confirmation before running a corrected command. The old
+  `10` (1-second auto-execute) is dangerous for destructive commands.
+- **Global hooks path**: `core.hooksPath = ~/.config/git/hooks` — see the
+  [Global Hooks](#3-global-hooks) section. Note that with `hooksPath` set,
+  per-repo `.git/hooks/` are ignored; the shipped dispatchers re-enable them.
+  The value is a fixed literal (git resolves relative `hooksPath` values
+  against the worktree, not the config file), so a custom `XDG_CONFIG_HOME`
+  triggers an installer warning with the exact `git config --global
+  core.hooksPath ...` command to run.
+- **GPG Signing**: `gpgSign = true` for both commits and tags.
+- **Histogram Diff**: `diff.algorithm = histogram` is more aware of code
+  structure than the default Myers algorithm.
+- **Rebase on Pull**: `pull.rebase = true` prevents accidental merge bubbles.
+- **Safe force push**: the `pf` alias is `push --force-with-lease
+  --force-if-includes` — a double lease: the remote-tracking ref must match
+  AND the remote tip must already be integrated into your local history
+  (checked via reflog). This prevents overwriting others' work even after a
+  background fetch.
 
-## 3. Recommended Aliases
+## 3. Global Hooks
 
-The configuration provides several aliases to speed up the workflow. Below are the most critical ones:
+`~/.config/git/hooks/` (managed by this repo) contains:
+
+- `prepare-commit-msg` — injects an AI-generated commit draft from
+  `.git/AI_COMMIT_MSG` into the editor buffer **only for plain `git commit`**
+  (never for `-m`/merge/amend), wrapped to 72 columns at injection (editor
+  independent), then chains the repository-local
+  `.git/hooks/prepare-commit-msg.local` if present. The draft buffer is kept
+  — an editor abort or GPG signing failure does not lose it — and is removed
+  by the `post-commit` dispatcher after the first successful commit (any
+  source, incl. `-m`/amend, which also prevents stale drafts from leaking
+  into later commits).
+- `pre-commit`, `commit-msg`, `pre-push`, `post-commit` — generic dispatchers
+  that chain `.git/hooks/<hook>.local`. Without a `.local` hook they are
+  inert, so existing per-repo hooks keep working under the global `hooksPath`.
+
+All hooks are inert by default; the AI draft flow only activates when an agent
+writes `.git/AI_COMMIT_MSG` (see the `git-commit-architect` skill).
+
+## 4. Recommended Aliases
 
 ### Visualization
 
-- `git lg`: A minimal, graph-based log view. Use this to quickly see the DAG structure.
-- `git lga`: A comprehensive log view with dates and author names.
+- `git lg`: minimal, graph-based log view.
+- `git lga`: comprehensive log view with dates and author names.
 
-### Maintenance
+### Diff
 
-- `git bclean`: Automatically deletes local branches that have already been merged into `HEAD`. Use this to keep your local environment sanitary.
+- `git ds`: diff of staged changes. `git dw`: whitespace-insensitive diff.
+- `git hdiff`: diff through the Hunk pager (requires `hunk`, installed with
+  `./install.sh --with-git-tui`); falls back to a plain `git diff` when
+  `hunk` is missing, so the alias never hard-errors.
 
 ### Rebase & Sync
 
-- `git up`: Equivalent to git `pull --rebase`. Always use this instead of git pull.
-- `git pf`: `push --force-with-lease`. This is the safe way to force push after a rebase. It ensures you don't overwrite work pushed by others that you haven't seen yet.
+- `git up`: `pull --rebase`. Always use this instead of a plain `git pull`.
+- `git pf`: safe force push (double lease, see above).
+- `git ri` / `git rc` / `git ra`: interactive rebase / continue / abort.
 
-## 4. Commit Message Convention
+### Maintenance
 
-We follow the Conventional Commits specification.
+- `git bclean [<ref>]`: deletes local branches already merged into `<ref>`
+  (default `HEAD`). Worktree-aware and POSIX-safe: skips the current branch,
+  branches checked out in other worktrees, and the protected set
+  (`main|master|develop|staging|trunk`). Safe `-d` delete only.
+- `git verify`: full object-database integrity check.
 
-### Format: `<type>: <subject>`
+## 5. Branch Cleanup and the Squash-Merge Blind Spot
 
-#### Types
+`git bclean` (and `git branch --merged` in general) detect merges **by
+ancestry**. GitHub's **Squash and Merge creates no ancestry**, so a
+squash-merged branch is invisible to `bclean` — `git branch -d` will refuse
+with "not fully merged".
 
-- `feat`: A new feature
-- `fix`: A bug fix
-- `refactor`: A code change that neither fixes a bug nor adds a feature
-- `style`: Changes that do not affect the meaning of the code (white-space, formatting, etc)
-- `docs`: Documentation only changes
-- `perf`: A code change that improves performance
-- `chore`: Changes to the build process or auxiliary tools and libraries
+- Preferred cleanup after a squash merge (also deletes the remote branch):
 
-#### Example
+  ```sh
+  gh pr merge --squash --delete-branch
+  ```
+
+- If you do not use `gh`, verify the PR is merged on GitHub, then delete the
+  branch deliberately with `git branch -D <branch>` — an explicit, informed
+  `-D` is legitimate; the ban is on casual/automated force deletion.
+
+## 6. Commit Message Convention
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/)
+specification.
+
+### Format: `<type>(<scope>): <subject>`
+
+- `feat`: a new feature
+- `fix`: a bug fix
+- `refactor`: a code change that neither fixes a bug nor adds a feature
+- `style`: changes that do not affect the meaning of the code
+- `docs`: documentation only changes
+- `perf`: a code change that improves performance
+- `chore`: changes to the build process or auxiliary tools
+
+### Wrapping
+
+Do **not** hand-wrap commit message lines: the editor wraps at 72 columns
+automatically (Vim `gitcommit` filetype, see `config/vim/vimrc`). Keep the
+subject under 50 characters and the body under ~72 characters per line as a
+soft habit.
+
+### Example
 
 ```txt
-feat: enhance installation robustness
+feat(install): enforce minimum tool versions via hybrid installation strategy
 
-Refactored `install.sh` to implement a Strategy Pattern for cleaner package manager detection.
+The installer now checks installed and candidate versions before falling back
+to manual builds, preventing silent toolchain downgrades.
+
+Key Changes:
+- Version sorter with GNU sort fallback (gsort on macOS)
+- Per-tool candidate resolution via apt/dnf/pacman/brew
+
+Verification:
+- Tested against apt and brew environments
 ```
 
-## 5. The Workflow
+## 7. The Workflow
 
 1. **Start**: `git sw -c feat/your-feature`
-2. **Work**: Make changes.
+2. **Work**: make changes.
 3. **Stage**: `git ap` (interactive add) to select specific hunks.
-4. **Commit**: `git ci` (verbose commit).
+4. **Commit**: `git ci` (verbose commit; AI drafts inject automatically via
+   the `prepare-commit-msg` hook — review and edit in Vim, then enter your GPG
+   passphrase in the pinentry prompt).
 5. **Sync**: `git up` (pull --rebase) to fetch latest main.
 6. **Push**: `git push` or `git pf` (if you rebased).
+7. **PR & cleanup**: open a PR, merge with **Squash and Merge**, then
+   `gh pr merge --squash --delete-branch` or `git bclean` where applicable.
+
+See [github-flow.md](github-flow.md) for the full step-by-step guide,
+including the AI-assisted Human-in-the-Loop flow.

--- a/docs/github-flow.md
+++ b/docs/github-flow.md
@@ -1,0 +1,178 @@
+# GitHub Flow (AI-Assisted HITL Edition)
+
+A step-by-step guide to contributing to GitHub repositories with a linear,
+signed, human-reviewed history. This is the modern successor to the classic
+GitHub Flow: `git switch`/`git restore` replace the overloaded `git checkout`,
+rebases happen in place (no branch-switching churn), and an AI agent may
+prepare commit drafts that you — and only you — review and sign.
+
+> **Prerequisites**: Git >= 2.37, a GPG key configured in
+> `config/git/config.ini`, and this repo's dotfiles installed. The AI parts
+> are optional (`./install.sh --with-git-tui --with-dsh`).
+
+## Principles
+
+1. **Non-blocking Human Oversight**: AI prepares drafts; humans review,
+   edit, and cryptographically sign. The agent never runs `git commit` or
+   `git push` (enforced by the `git-commit-architect` skill).
+2. **Zero Filesystem Churn**: never switch to `main` just to rebase — sync
+   the remote ref and rebase in place.
+3. **Destructive Command Ban**: `git branch -D` (casual use) and un-leased
+   `git push -f` are forbidden. Use `git pf` and informed deletions only.
+
+## Steps
+
+### 1. Get the repository
+
+- **Collaborating on someone else's project**: fork it on GitHub, then:
+
+  ```sh
+  git clone git@github.com:<you>/<repo>.git
+  cd <repo>
+  git remote add upstream <original-repo-url>   # e.g. https://github.com/author/repo
+  ```
+
+- **Your own project**: just clone your repository. Skip the `upstream` step.
+
+### 2. Create a feature branch
+
+Never commit directly on `main`. Always branch off the latest remote `main`:
+
+```sh
+git fetch origin
+git switch -c feat/<your-feature> origin/main
+```
+
+(`git switch -c` replaces the old `git checkout -b`; `git switch` for
+branch switching, `git restore` for file restoration — `git checkout` no
+longer needs to do both jobs.)
+
+### 3. Develop — with or without the AI co-worker
+
+Program as usual. If you are using the AI workflow:
+
+1. The agent audits `git diff --staged` / `git diff`.
+2. The agent writes a Conventional Commit draft to `.git/AI_COMMIT_MSG`
+   (never commits itself).
+3. You are notified to review — in [Hunk](https://github.com/modem-dev/hunk)
+   (`hunk diff`), [lazygit](https://github.com/jesseduffield/lazygit) (key
+   `H`), or simply in your editor.
+
+### 4. Stage, review, and sign the commit
+
+```sh
+git add -p          # stage hunks selectively (alias: git ap)
+git commit          # alias: git ci
+```
+
+For a plain `git commit`, the `prepare-commit-msg` hook injects the agent's
+draft into your editor automatically (zero copy-paste) — already wrapped at
+72 columns at injection, independent of your editor. Review and edit it —
+Vim additionally rewraps long lines **on save** (vimrc `BufWritePre`, a
+second line of defense for your hand edits) — save (`:wq`), and enter your
+GPG passphrase in the pinentry prompt. The AI never sees your key.
+
+> The hook does **not** inject into `git commit -m "..."`: a hand-written
+> message always wins.
+
+### 5. Sync with remote main — in place, zero churn
+
+Do **not** switch to `main` and back (that re-indexes IDEs and invalidates
+build caches twice). Stay on your feature branch:
+
+```sh
+git fetch origin main
+git rebase origin/main
+```
+
+On conflict: resolve manually, `git add <files>`, then `git rebase --continue`.
+
+### 6. Push (and safe force-push after a rebase)
+
+```sh
+git push -u origin <branch>          # first push (autoSetupRemote may make this just: git push)
+git pf                               # after a rebase: force-with-lease + force-if-includes
+```
+
+`git pf` is `push --force-with-lease --force-if-includes`: it refuses to
+overwrite the remote if your local history does not already contain the
+remote's latest commit — even after a background `fetch` updated the
+remote-tracking ref. Plain `git push -f` is banned.
+
+### 7. Open a Pull Request
+
+On GitHub, open a PR from your feature branch. If you use the GitHub CLI:
+
+```sh
+gh pr create --body-file .git/AI_PR_BODY
+```
+
+The `git-pr-architect` skill drafts the description into `.git/AI_PR_BODY`
+(`## Summary`, `## Key Changes`, `## Impact`, `## Verification`,
+`## Related Issues` — it never runs `gh pr create` itself; publishing is
+yours). Without an agent, use the same template manually.
+
+### 8. Merge with Squash and Merge
+
+The project leader (or you, on your own project) merges with **Squash and
+Merge** to keep `main` linear and atomic. Optionally, set the squash commit
+message from the PR description.
+
+### 9. Clean up
+
+- Delete the remote branch on GitHub, or with `gh pr merge --squash
+  --delete-branch` (merges *and* deletes remote + local branch in one step).
+- Back on your machine, sync and clean local branches:
+
+  ```sh
+  git switch main
+  git pull --rebase
+  git bclean
+  ```
+
+> **Squash-merge caveat**: `git bclean` detects merged branches by ancestry,
+> and squash merges create no ancestry — so a squash-merged branch is *not*
+> auto-removed. That is safe-by-design. If `gh` was not used and the PR is
+> confirmed merged, delete that one branch deliberately:
+> `git branch -D <branch>`.
+
+### 10. Loop
+
+Start again from step 2.
+
+## FAQ
+
+**Q: Why do I get "Authentication failed" on push?**
+
+Password authentication was removed from GitHub in 2021. Use SSH or a
+fine-grained token:
+
+```sh
+git remote set-url origin git@github.com:<user>/<repo>.git
+# or: git remote set-url origin https://<token>@github.com/<user>/<repo>.git
+```
+
+**Q: Why does `git commit` fail with "gpg: signing failed"?**
+
+You have no usable GPG key for `commit.gpgSign = true`. Generate one
+(`gpg --full-generate-key`), set `[user] signingkey` in
+`config/git/config.ini`, and export it to GitHub (Settings → SSH and GPG
+keys). If you use a smartcard/hardware key, make sure the agent is running
+and `GPG_TTY` is exported (the dotfiles already do this).
+
+**Q: The pinentry prompt hangs or never appears.**
+
+Your distro's pinentry program is missing. The installer configures
+`gpg-agent.conf` automatically (pinentry-mac / pinentry-curses / pinentry);
+install the matching package or check `~/.local/share/gnupg/gpg-agent.conf`.
+
+**Q: Why is my feature branch not deleted by `git bclean`?**
+
+It was squash-merged (no ancestry) — see the caveat in step 9.
+
+**Q: Where does the AI draft come from?**
+
+An agent following the `git-commit-architect` skill writes
+`.git/AI_COMMIT_MSG`; the global `prepare-commit-msg` hook injects it. If the
+file does not exist, the hook does nothing — the workflow is fully manual
+when no agent is involved.

--- a/install.sh
+++ b/install.sh
@@ -4,101 +4,119 @@
 # Dotfiles Installation Script
 #
 # Description:
-#   Sets up the Bash environment, installs dependencies, and configures symlinks
-#   compliant with the XDG Base Directory Specification.
+#   Configures user development environment, resolves dependencies with version
+#   constraints, and links dotfiles compliant with XDG Base Directory specs.
 #
-# Author: Traxton Chen (Refactored)
+# Usage:
+#   ./install.sh [--with-git-tui] [--with-dsh] [--help]
 # ==============================================================================
 
-# Exit immediately if a command exits with a non-zero status.
-# Treat unset variables as an error.
 set -euo pipefail
 
 # ==============================================================================
-# Global Configuration & Constants
+# 1. Constants & Global State
 # ==============================================================================
 
-# Global variables for Package Manager Strategy.
-# These will be populated by 'detect_environment'.
-PM_STRATEGY=""
-UPDATE_CMD=""
-INSTALL_CMD=""
-SORT_CMD="sort"
+# Script Metadata
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 
-# Distro-specific packages (e.g., build tools, platform-specific naming variations)
+# Color Palette (POSIX compliant formatting)
+readonly CLR_RESET="\033[0m"
+readonly CLR_BLUE="\033[1;34m"
+readonly CLR_GREEN="\033[1;32m"
+readonly CLR_YELLOW="\033[1;33m"
+readonly CLR_RED="\033[1;31m"
+readonly CLR_MUTED="\033[0;37m"
+
+# Feature Flags
+FLAG_GIT_TUI=0
+FLAG_WITH_DSH=0
+
+# Shell guidance shown in the installer's final message when the user's login
+# shell is not bash (set by ensure_bash_shell; empty = keep the default message).
+BASH_SHELL_GUIDANCE=""
+
+# Dynamic Environment & Package Manager State
+PM_STRATEGY=""
+PM_UPDATE_CMD=()
+PM_INSTALL_CMD=()
+SORT_CMD="sort"
 DISTRO_PKGS=()
 
+# Resource Management State
+TMP_DIRS=()
+BACKUP_DIR=""
+
 # ==============================================================================
-# Utility Functions (Logging & Basic Checks)
+# 2. Cleanup & Signal Lifecycle Management
 # ==============================================================================
 
-# Print a message in a consistent, colorful format.
-# Usage: log "This is a message."
-log() {
-    # Blue color for the prompt arrow
-    echo -e "\n\033[1;34m❯❯❯ $1\033[0m"
+cleanup() {
+    local exit_code=$?
+    # Prevent recursive signal handling during termination
+    trap - EXIT INT TERM HUP
+
+    for dir in "${TMP_DIRS[@]}"; do
+        if [[ -d "$dir" ]]; then
+            rm -rf "$dir"
+        fi
+    done
+
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM HUP
+
+create_temp_dir() {
+    local tmp
+    tmp="$(mktemp -d)"
+    TMP_DIRS+=("$tmp")
+    printf '%s\n' "$tmp"
 }
 
-# Print an error message.
-# Usage: error "Something went wrong."
-error() {
-    # Red color for error messages
-    echo -e "\n\033[1;31mError: $1\033[0m" >&2
-}
+# ==============================================================================
+# 3. Logging & Terminal Output
+# ==============================================================================
 
-# Check if a command is available in the PATH.
-# Usage: command_exists "git"
+log_step()    { printf "\n${CLR_BLUE}❯❯❯ %s${CLR_RESET}\n" "$1"; }
+log_info()    { printf "  ${CLR_MUTED}%s${CLR_RESET}\n" "$1"; }
+log_success() { printf "  ${CLR_GREEN}✓ %s${CLR_RESET}\n" "$1"; }
+log_warn()    { printf "  ${CLR_YELLOW}⚠ %s${CLR_RESET}\n" "$1"; }
+log_error()   { printf "\n${CLR_RED}Error: %s${CLR_RESET}\n" "$1" >&2; }
+
+# ==============================================================================
+# 4. System & Version Utilities
+# ==============================================================================
+
 command_exists() { command -v "$1" >/dev/null 2>&1; }
 
-# ==============================================================================
-# Version Control Logic
-# ==============================================================================
-
-# Initialize the sort command based on system capabilities.
-# macOS 'sort' does not support -V, so we rely on 'gsort' from coreutils.
 init_version_sorter() {
-    # Check if default sort supports version sort
     if sort --version-sort </dev/null >/dev/null 2>&1; then
         SORT_CMD="sort"
     elif command_exists gsort; then
         SORT_CMD="gsort"
     else
-        # Fallback warning, though install_packages should handle this for macOS
-        if [[ "$PM_STRATEGY" == "brew" ]]; then
-            log "Warning: GNU sort not found. 'coreutils' will be installed to ensure correct versioning."
-        fi
         SORT_CMD="sort"
+        if [[ "$PM_STRATEGY" == "brew" ]]; then
+            log_warn "GNU sort not found. 'coreutils' should be installed for accurate version sorting."
+        fi
     fi
 }
 
-# Compare two semantic versions.
-# Usage: compare_versions_lt "curr_ver" "req_ver"
-# Returns 0 (true) if current < required (update needed).
-# Returns 1 (false) if current >= required (sufficient).
 compare_versions_lt() {
     local v1="$1"
     local v2="$2"
 
-    # Treat empty v1 as the lowest possible version (needs update)
     [[ -z "$v1" ]] && return 0
-
-    # If versions are identical, strictly not less than.
     [[ "$v1" == "$v2" ]] && return 1
 
-    # Sort versions using sort -V (version sort) and pick the top one.
-    # If the smallest of the two is v1, then v1 < v2.
     local smallest
     smallest=$(printf '%s\n%s\n' "$v1" "$v2" | $SORT_CMD -V | head -n1)
-
     [[ "$smallest" == "$v1" ]]
 }
 
-# Extract the version string from an installed command.
-# Heuristics are used to parse different output formats from various tools.
 get_installed_version() {
     local cmd="$1"
-
-    # Priority check: Check local bin first to avoid detecting system binary if shadowed
     local local_bin="$HOME/.local/bin/$cmd"
     local target_cmd="$cmd"
 
@@ -108,250 +126,476 @@ get_installed_version() {
         return 1
     fi
 
-    # Retrieve version output once
     local output
     output=$(LC_ALL=C "$target_cmd" --version 2>&1 | head -n1)
 
     case "$cmd" in
-        starship)
-            # Format: "starship 1.22.1" -> "1.22.1"
-            awk '{print $2}' <<< "$output"
+        starship) awk '{print $2}' <<< "$output" ;;
+        fzf)      awk '{print $1}' <<< "$output" ;;
+        lazygit)
+            # Format: "..., version='0.50.0+ds1', ..., git version=2.47.3" -> "0.50.0"
+            # Target the isolated 'version=' field and ignore trailing 'git version='
+            grep -oE '(^|,)[[:space:]]*version=[^,]+' <<< "$output" \
+                | grep -oE '[0-9]+(\.[0-9]+)+' \
+                | head -n1
             ;;
-        fzf)
-            # Format: "0.60 (devel)" -> "0.60"
-            awk '{print $1}' <<< "$output"
-            ;;
-        *)
-            # Fallback: Grab the last word (e.g., "git version 2.34.1" -> "2.34.1")
-            awk '{print $NF}' <<< "$output"
-            ;;
+        *)        awk '{print $NF}' <<< "$output" ;;
     esac
 }
 
-# Specific parsing logic for fetching version from remote repositories.
-# Note: This is brittle and depends on the specific output format of PMs.
 get_candidate_version() {
     local pkg="$1"
     local version=""
 
     case "$PM_STRATEGY" in
         apt)
-            # Parse 'apt-cache policy' for Candidate version
             version=$(LC_ALL=C apt-cache policy "$pkg" 2>/dev/null | grep 'Candidate:' | awk '{print $2}' | cut -d- -f1)
             ;;
         dnf)
-            # Parse 'dnf info' for Version
             version=$(LC_ALL=C dnf info --available "$pkg" 2>/dev/null | grep '^Version' | head -n1 | awk '{print $3}' | cut -d: -f2)
             ;;
         pacman)
-            # Parse 'pacman -Si' for Version
             version=$(LC_ALL=C pacman -Si "$pkg" 2>/dev/null | grep '^Version' | awk '{print $3}' | cut -d- -f1)
             ;;
         brew)
-            # Parse 'brew info'
             version=$(LC_ALL=C brew info "$pkg" 2>/dev/null | head -n1 | awk '{print $4}')
             ;;
     esac
 
-    # Trim whitespace
-    echo "$version" | xargs
+    printf '%s\n' "$version" | xargs
 }
 
 # ==============================================================================
-# Environment Detection
+# 5. Environment & Package Manager Detection
 # ==============================================================================
 
-detect_environment() {
-    # Pre-flight check for sudo/root capabilities
-    if ! command_exists sudo && ! command_exists brew; then
-        error "Administrator privileges (sudo) or Homebrew are required."
-        exit 1
-    fi
+init_xdg_env() {
+    log_step "Initializing XDG Environment & Paths"
 
-    # Refresh sudo privileges upfront to prevent timeouts during long installs
-    if command_exists sudo; then
-        sudo -v
-    fi
-
-    # Detect Package Manager and configure commands
-    if command_exists apt-get; then
-        PM_STRATEGY="apt"
-        UPDATE_CMD="sudo apt-get update"
-        INSTALL_CMD="sudo apt-get install -y"
-        DISTRO_PKGS=("build-essential" "fd-find")
-
-    elif command_exists dnf; then
-        PM_STRATEGY="dnf"
-        UPDATE_CMD="sudo dnf makecache"
-        INSTALL_CMD="sudo dnf install -y"
-        DISTRO_PKGS=("@development-tools" "fd-find")
-
-    elif command_exists pacman; then
-        PM_STRATEGY="pacman"
-        UPDATE_CMD="sudo pacman -Sy"
-        INSTALL_CMD="sudo pacman -S --noconfirm --needed"
-        DISTRO_PKGS=("base-devel" "fd")
-
-    elif command_exists brew; then
-        PM_STRATEGY="brew"
-        UPDATE_CMD="brew update"
-        INSTALL_CMD="brew install"
-        # Homebrew needs coreutils for 'gsort' (GNU sort) to support version sorting
-        DISTRO_PKGS=("coreutils" "fd")
-
-    else
-        error "Unsupported OS. Could not detect apt, dnf, pacman, or brew."
-        exit 1
-    fi
-
-    log "Environment Detected: $PM_STRATEGY"
-}
-
-# ==============================================================================
-# Installation Logic
-# ==============================================================================
-
-## Base Package Installation
-install_packages() {
-    log "Installing base packages..."
-
-    # Common utilities list.
-    # Note: 'fzf' and 'starship' are handled separately via verify_and_install_tool.
-    local pkgs=(curl gawk git gnupg2 man-db ripgrep vim zoxide)
-
-    # Append distro-specific packages
-    if [ ${#DISTRO_PKGS[@]} -gt 0 ]; then
-        pkgs+=("${DISTRO_PKGS[@]}")
-    fi
-
-    log "Updating repositories..."
-    $UPDATE_CMD
-
-    log "Installing: ${pkgs[*]}"
-    $INSTALL_CMD "${pkgs[@]}"
-
-    # Re-evaluate sort command after installation (specifically for macOS/coreutils)
-    init_version_sorter
-
-    log "Base packages installed."
-}
-
-## Specific Install Callbacks (Fallback Strategies)
-# These functions are called only when the system package manager fails to provide a sufficient version of the tool.
-
-install_fzf_manual() {
-    log "Fallback: Installing fzf from source..."
-
-    local fzf_dir="$XDG_DATA_HOME/fzf"
-    local bin_dest="$HOME/.local/bin/fzf"
-
-    # Clean previous attempts
-    [ -d "$fzf_dir" ] && rm -rf "$fzf_dir"
-
-    if git clone --depth 1 https://github.com/junegunn/fzf.git "$fzf_dir"; then
-        # Run installer, generate binary only
-        "$fzf_dir/install" --bin
-
-        # Symlink to local bin
-        mkdir -p "$(dirname "$bin_dest")"
-        ln -sf "$fzf_dir/bin/fzf" "$bin_dest"
-
-        log "fzf installed manually to $bin_dest"
-    else
-        error "Failed to clone fzf repository."
-        exit 1
-    fi
-}
-
-install_starship_manual() {
-    log "Fallback: Installing Starship via official script..."
-
-    # Try default install (usually /usr/local/bin, requires sudo)
-    if ! curl -sS https://starship.rs/install.sh | sh -s -- -y; then
-        log "System-wide install failed. Attempting local install to ~/.local/bin..."
-        curl -sS https://starship.rs/install.sh | sh -s -- -y -b "$HOME/.local/bin"
-    fi
-}
-
-## Strategy Validator
-# Checks if a tool meets version requirements. Priorities:
-# 1. Current Local Version (if sufficient, skip)
-# 2. Package Manager Version (if sufficient, install)
-# 3. Manual Installation (Callback function)
-#
-# Arguments:
-#   $1: cmd_name (e.g., "fzf")
-#   $2: pkg_name (e.g., "fzf")
-#   $3: req_ver  (e.g., "0.60")
-#   $4: callback (Function name to call if PM fails)
-verify_and_install_tool() {
-    local cmd="$1"
-    local pkg="$2"
-    local req_ver="$3"
-    local callback="$4"
-    local current_ver=""
-    local candidate_ver=""
-
-    log "Checking Requirement: $cmd >= $req_ver"
-
-    # Step 1: Check if currently installed version is sufficient
-    if command_exists "$cmd"; then
-        current_ver=$(get_installed_version "$cmd")
-        if ! compare_versions_lt "$current_ver" "$req_ver"; then
-            log "✓ Local $cmd version ($current_ver) is sufficient."
-            return 0
-        fi
-        log "⚠ Local $cmd version ($current_ver) is outdated."
-    fi
-
-    # Step 2: Check Package Manager Candidate
-    log "Checking repository candidate for '$pkg'..."
-    candidate_ver=$(get_candidate_version "$pkg")
-
-    # If candidate exists AND is >= required version
-    if [[ -n "$candidate_ver" ]] && ! compare_versions_lt "$candidate_ver" "$req_ver"; then
-        log "✓ Repository version ($candidate_ver) is sufficient. Installing via $PM_STRATEGY..."
-        $INSTALL_CMD "$pkg"
-
-        # Verification Post-Install
-        current_ver=$(get_installed_version "$cmd")
-        if compare_versions_lt "$current_ver" "$req_ver"; then
-            error "Package manager installed $current_ver, which is still too old. Proceeding to fallback."
-            # Fallthrough to callback if PM failed to deliver promises
-        else
-            return 0
-        fi
-    else
-        log "⚠ Repository version (${candidate_ver:-not found}) is insufficient."
-    fi
-
-    # Step 3: Fallback to Manual Installation
-    log "Proceeding with manual installation strategy ($callback)..."
-    eval "$callback"
-}
-
-# ==============================================================================
-# Configuration & Dotfiles Linking
-# ==============================================================================
-
-# Set up XDG Base Directories to organize config, data, and cache files.
-# Ref: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-setup_xdg_dirs() {
-    log "Configuring XDG Base Directories..."
     export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
     export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
     export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
     export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+    export PNPM_HOME="${PNPM_HOME:-$XDG_DATA_HOME/pnpm}"
 
-    mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"
-    mkdir -p "$HOME/.local/bin"
+    mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$HOME/.local/bin" "$PNPM_HOME"
 
-    log "XDG directories ready."
+    # Inject paths into the current execution subshell immediately
+    if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+    if [[ ":$PATH:" != *":$PNPM_HOME/bin:"* && -d "$PNPM_HOME/bin" ]]; then
+        export PATH="$PNPM_HOME/bin:$PATH"
+    fi
+
+    log_success "XDG Base Directories and Execution Paths prepared."
 }
 
-# Configure GnuPG permissions strictly as required by the tool.
+detect_environment() {
+    if ! command_exists sudo && ! command_exists brew; then
+        log_error "Administrator privileges (sudo) or Homebrew are required."
+        exit 1
+    fi
+
+    if command_exists sudo; then
+        sudo -v
+    fi
+
+    if command_exists apt-get; then
+        PM_STRATEGY="apt"
+        PM_UPDATE_CMD=("sudo" "apt-get" "update")
+        PM_INSTALL_CMD=("sudo" "apt-get" "install" "-y")
+        DISTRO_PKGS=("build-essential" "fd-find" "gh" "pinentry-curses" "libatomic1")
+    elif command_exists dnf; then
+        PM_STRATEGY="dnf"
+        PM_UPDATE_CMD=("sudo" "dnf" "makecache")
+        PM_INSTALL_CMD=("sudo" "dnf" "install" "-y")
+        DISTRO_PKGS=("@development-tools" "fd-find" "gh" "pinentry" "libatomic")
+    elif command_exists pacman; then
+        PM_STRATEGY="pacman"
+        PM_UPDATE_CMD=("sudo" "pacman" "-Sy")
+        PM_INSTALL_CMD=("sudo" "pacman" "-S" "--noconfirm" "--needed")
+        DISTRO_PKGS=("base-devel" "fd" "github-cli" "pinentry")
+    elif command_exists brew; then
+        PM_STRATEGY="brew"
+        PM_UPDATE_CMD=("brew" "update")
+        PM_INSTALL_CMD=("brew" "install")
+        DISTRO_PKGS=("coreutils" "fd" "gh" "pinentry-mac")
+    else
+        log_error "Unsupported OS. Could not detect apt, dnf, pacman, or brew."
+        exit 1
+    fi
+
+    log_info "Package Manager Strategy: $PM_STRATEGY"
+}
+
+# ==============================================================================
+# 6. Tool Provisioning & Fallbacks
+# ==============================================================================
+
+install_base_packages() {
+    log_step "Installing Base System Packages"
+
+    local pkgs=(curl gawk git gnupg2 man-db ripgrep vim zoxide)
+    if [[ ${#DISTRO_PKGS[@]} -gt 0 ]]; then
+        pkgs+=("${DISTRO_PKGS[@]}")
+    fi
+
+    log_info "Updating repository indexes..."
+    "${PM_UPDATE_CMD[@]}"
+
+    log_info "Installing: ${pkgs[*]}"
+    "${PM_INSTALL_CMD[@]}" "${pkgs[@]}"
+
+    init_version_sorter
+    log_success "Base system packages installed successfully."
+}
+
+ensure_tool_version() {
+    local cmd="$1"
+    local pkg="$2"
+    local req_ver="$3"
+    local fallback_fn="$4"
+    local current_ver=""
+    local candidate_ver=""
+
+    log_step "Checking Requirement: $cmd (>= $req_ver)"
+
+    # Step 1: Check existing local binary
+    if command_exists "$cmd"; then
+        current_ver=$(get_installed_version "$cmd")
+        if ! compare_versions_lt "$current_ver" "$req_ver"; then
+            log_success "Local $cmd version ($current_ver) satisfies constraint."
+            return 0
+        fi
+        log_warn "Local $cmd version ($current_ver) is outdated."
+    fi
+
+    # Step 2: Check repository candidate
+    log_info "Querying upstream candidate for '$pkg'..."
+    candidate_ver=$(get_candidate_version "$pkg")
+
+    if [[ -n "$candidate_ver" ]] && ! compare_versions_lt "$candidate_ver" "$req_ver"; then
+        log_info "Repository candidate ($candidate_ver) satisfies constraint. Installing via $PM_STRATEGY..."
+        "${PM_INSTALL_CMD[@]}" "$pkg"
+
+        current_ver=$(get_installed_version "$cmd")
+        if ! compare_versions_lt "$current_ver" "$req_ver"; then
+            log_success "$cmd ($current_ver) successfully installed via $PM_STRATEGY."
+            return 0
+        fi
+        log_warn "Package manager installed $current_ver (below required $req_ver). Proceeding to fallback."
+    else
+        log_warn "Repository candidate (${candidate_ver:-none}) is insufficient or not available."
+    fi
+
+    # Step 3: Trigger safe dynamic fallback
+    log_info "Executing fallback installer: $fallback_fn"
+    "$fallback_fn"
+}
+
+# --- Specific Tool Fallback Implementations ---
+
+install_fzf_fallback() {
+    log_info "Compiling fzf from source..."
+    local fzf_dir="$XDG_DATA_HOME/fzf"
+    local bin_dest="$HOME/.local/bin/fzf"
+
+    [[ -d "$fzf_dir" ]] && rm -rf "$fzf_dir"
+
+    if git clone --depth 1 https://github.com/junegunn/fzf.git "$fzf_dir"; then
+        "$fzf_dir/install" --bin
+        mkdir -p "$(dirname "$bin_dest")"
+        ln -sf "$fzf_dir/bin/fzf" "$bin_dest"
+        log_success "fzf successfully linked to $bin_dest"
+    else
+        log_error "Failed to clone fzf repository."
+        exit 1
+    fi
+}
+
+install_starship_fallback() {
+    log_info "Installing Starship via official installer..."
+    if ! curl -sS https://starship.rs/install.sh | sh -s -- -y; then
+        log_warn "System-wide install failed. Installing locally to ~/.local/bin..."
+        curl -sS https://starship.rs/install.sh | sh -s -- -y -b "$HOME/.local/bin"
+    fi
+    log_success "Starship installation completed."
+}
+
+ensure_node_runtime() {
+    if command_exists node; then
+        local node_major
+        node_major="$(node --version 2>/dev/null | sed -E 's/^v([0-9]+).*/\1/')"
+        if [[ -n "$node_major" ]] && [[ "$node_major" -ge 18 ]] 2>/dev/null; then
+            log_success "Node.js $(node --version 2>/dev/null) detected (>= 18)."
+            return 0
+        fi
+        log_warn "Detected Node.js $(node --version 2>/dev/null || printf 'unknown') is older than 18."
+    fi
+
+    log_info "Provisioning Node.js LTS via pnpm runtime..."
+    if ! pnpm runtime set node lts -g && ! pnpm env use --global lts; then
+        log_warn "Node.js provisioning via pnpm failed."
+        return 1
+    fi
+    return 0
+}
+
+install_hunk_fallback() {
+    if command_exists pnpm && ensure_node_runtime; then
+        log_info "Installing Hunk via pnpm global repository..."
+        if pnpm add -g hunkdiff; then
+            log_success "Hunk installed via pnpm into $PNPM_HOME/bin."
+            return 0
+        fi
+        log_warn "pnpm global installation failed; switching to prebuilt binary script."
+    fi
+
+    log_info "Installing Hunk via standalone official installer (XDG path)..."
+    # The official installer honors HUNK_INSTALL_DIR / HUNK_NO_MODIFY_PATH env
+    # vars: install under $XDG_DATA_HOME/hunk and never touch shell startup
+    # files (keeps the README's XDG promise: nothing pollutes $HOME).
+    local hunk_dir="$XDG_DATA_HOME/hunk"
+    if ! HUNK_INSTALL_DIR="$hunk_dir/bin" HUNK_NO_MODIFY_PATH=1 \
+        curl -fsSL https://hunk.dev/install.sh | sh -s; then
+        log_error "Failed to install Hunk standalone binary."
+        exit 1
+    fi
+
+    local hunk_bin="$hunk_dir/bin/hunk"
+    if [[ -x "$hunk_bin" ]] && ! command_exists hunk; then
+        mkdir -p "$HOME/.local/bin"
+        ln -sf "$hunk_bin" "$HOME/.local/bin/hunk"
+        log_info "Symlinked $hunk_bin to ~/.local/bin/hunk"
+    fi
+    log_success "Hunk installed."
+}
+
+install_lazygit_fallback() {
+    log_info "Fetching Lazygit release binary from GitHub..."
+
+    local os arch
+    case "$(uname -s)" in
+        Linux)  os="linux" ;;
+        Darwin) os="darwin" ;;
+        *) log_error "Unsupported OS for Lazygit manual build."; exit 1 ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64|amd64)   arch="x86_64" ;;
+        aarch64|arm64)  arch="arm64" ;;
+        *) log_error "Unsupported CPU architecture for Lazygit manual build."; exit 1 ;;
+    esac
+
+    local release_url
+    release_url="$(curl -fsSL https://api.github.com/repos/jesseduffield/lazygit/releases/latest \
+        | grep -oE "\"browser_download_url\": \"[^\"]*lazygit_[0-9.]+_${os}_${arch}\\.tar\\.gz\"" \
+        | head -n1 | cut -d'"' -f4)"
+
+    if [[ -z "$release_url" ]]; then
+        log_error "Failed to resolve Lazygit release artifact URL for ${os}_${arch}."
+        exit 1
+    fi
+
+    local tmp_dir
+    tmp_dir="$(create_temp_dir)"
+
+    curl -fsSL "$release_url" -o "$tmp_dir/lazygit.tar.gz" || { log_error "Lazygit download failed."; exit 1; }
+    tar -xzf "$tmp_dir/lazygit.tar.gz" -C "$tmp_dir" || { log_error "Lazygit extraction failed."; exit 1; }
+
+    mkdir -p "$HOME/.local/bin"
+    install -m 755 "$tmp_dir/lazygit" "$HOME/.local/bin/lazygit"
+    log_success "Lazygit installed to ~/.local/bin/lazygit"
+}
+
+install_pnpm() {
+    log_step "Verifying pnpm Infrastructure (Standalone Native)"
+
+    local pnpm_version="${PNPM_VERSION:-12.0.0-rc.9}"
+
+    if command_exists pnpm; then
+        local existing_pnpm_version
+        existing_pnpm_version="$(pnpm --version 2>/dev/null || true)"
+        log_success "pnpm is already accessible: ${existing_pnpm_version:-unknown}"
+        # `pnpm runtime` (see ensure_node_runtime) requires pnpm >= 11.
+        if [[ -n "$existing_pnpm_version" ]] && compare_versions_lt "$existing_pnpm_version" "11"; then
+            log_warn "Existing pnpm $existing_pnpm_version is below 11 — 'pnpm runtime' may be unavailable."
+        fi
+        return 0
+    fi
+
+    local fake_home
+    fake_home="$(create_temp_dir)"
+
+    log_info "Executing standalone pnpm installer into $PNPM_HOME..."
+    if ! curl -fsSL https://get.pnpm.io/install.sh \
+        | env HOME="$fake_home" PNPM_HOME="$PNPM_HOME" PNPM_VERSION="$pnpm_version" SHELL="$(command -v bash)" sh -; then
+        log_error "pnpm installation failed."
+        exit 1
+    fi
+
+    if [[ -x "$PNPM_HOME/bin/pnpm" ]]; then
+        if [[ ":$PATH:" != *":$PNPM_HOME/bin:"* ]]; then
+            export PATH="$PNPM_HOME/bin:$PATH"
+            log_info "Prepended $PNPM_HOME/bin to current execution PATH."
+        fi
+        log_success "pnpm installed to $PNPM_HOME/bin"
+    else
+        log_error "pnpm binary not found at $PNPM_HOME/bin/pnpm."
+        exit 1
+    fi
+}
+
+install_dsh() {
+    log_step "Installing DeepSeek Harness Ecosystem"
+
+    local dsh_home="${DSH_HOME:-$XDG_DATA_HOME/dsh}"
+    export DSH_HOME="$dsh_home"
+
+    if command_exists dsh; then
+        log_success "dsh is already available: $(dsh --version 2>/dev/null || printf 'unknown')"
+        return 0
+    fi
+
+    if ! command_exists pnpm; then
+        log_error "pnpm is required to deploy DeepSeek Harness."
+        exit 1
+    fi
+
+    if ! ensure_node_runtime; then
+        log_error "A valid Node.js runtime (>= 18) is required for DeepSeek Harness."
+        exit 1
+    fi
+
+    if ! pnpm add -g @deepseek-ai/dsh; then
+        log_error "DeepSeek Harness global package installation failed."
+        exit 1
+    fi
+
+    log_success "DeepSeek Harness installed successfully."
+}
+
+check_git_version() {
+    log_step "Validating Git Feature Constraints"
+    local ver
+    ver=$(get_installed_version "git")
+
+    if [[ -z "$ver" ]]; then
+        log_error "Git binary missing from environment."
+        exit 1
+    fi
+
+    if compare_versions_lt "$ver" "2.37"; then
+        log_warn "Git $ver detected. Dotfiles configuration requires Git >= 2.37:"
+        log_info "- push.autoSetupRemote (2.37), merge.conflictstyle=zdiff3 (2.35)"
+        log_info "- help.autocorrect=prompt (2.34), push --force-if-includes (2.30)"
+        log_warn "Please upgrade Git. Some configurations will degrade silently."
+    else
+        log_success "Git $ver satisfies requirements (>= 2.37)."
+    fi
+}
+
+# ==============================================================================
+# 7. Dotfiles, Symlinks & Environment Configuration
+# ==============================================================================
+
+ensure_backup_dir() {
+    if [[ -z "$BACKUP_DIR" ]]; then
+        BACKUP_DIR="$HOME/.dotfiles_backup_$(date +%Y%m%d_%H%M%S)"
+        mkdir -p "$BACKUP_DIR"
+        log_info "Allocated backup directory: $BACKUP_DIR"
+    fi
+}
+
+sync_symlink() {
+    local src="$1"
+    local dest="$2"
+
+    mkdir -p "$(dirname "$dest")"
+
+    # Lazy backup trigger: only backup if the destination physically exists and is not a symlink
+    if [[ -e "$dest" && ! -L "$dest" ]]; then
+        ensure_backup_dir
+        log_warn "Backing up conflicting target: $dest -> $BACKUP_DIR/"
+        mv "$dest" "$BACKUP_DIR/"
+    fi
+
+    # Guard against dangling non-symlink directories that failed to move
+    if [[ -d "$dest" && ! -L "$dest" ]]; then
+        log_error "Destination $dest remains a non-symlink directory. Skipping link."
+        return 1
+    fi
+
+    ln -sf "$src" "$dest"
+    log_info "Linked: $dest -> $src"
+}
+
+setup_symlinks() {
+    log_step "Synchronizing Dotfiles & Symlinks"
+
+    # Deterministic ordered linking specifications: "rel_src:abs_dest"
+    local link_specs=(
+        ".bash_profile:$HOME/.bash_profile"
+        ".bashrc:$HOME/.bashrc"
+        "config/starship.toml:$XDG_CONFIG_HOME/starship.toml"
+        "config/bash:$XDG_CONFIG_HOME/bash"
+        "config/git:$XDG_CONFIG_HOME/git"
+        "config/vim:$XDG_CONFIG_HOME/vim"
+    )
+
+    if [[ "$FLAG_GIT_TUI" -eq 1 ]]; then
+        link_specs+=(
+            "config/lazygit:$XDG_CONFIG_HOME/lazygit"
+            "config/hunk:$XDG_CONFIG_HOME/hunk"
+        )
+    fi
+
+    for spec in "${link_specs[@]}"; do
+        local rel_src="${spec%%:*}"
+        local abs_dest="${spec#*:}"
+        sync_symlink "$SCRIPT_DIR/$rel_src" "$abs_dest"
+    done
+
+    # Legacy ~/.vimrc takes precedence over the XDG vimrc (Vim reads ~/.vimrc
+    # first), so commit-message wrapping (config/vim/vimrc) would silently not
+    # apply. Warn so the user can remove or merge it deliberately.
+    if [[ -f "$HOME/.vimrc" ]]; then
+        log_warn "$HOME/.vimrc exists and overrides $XDG_CONFIG_HOME/vim/vimrc"
+        log_info "Remove it or merge your settings into the XDG vimrc to enable commit-message wrapping."
+    fi
+
+    # Dynamic DeepSeek Harness Skills Symlinks
+    if [[ "$FLAG_WITH_DSH" -eq 1 ]]; then
+        local dsh_home="${DSH_HOME:-$XDG_DATA_HOME/dsh}"
+        for skill_dir in "$SCRIPT_DIR"/skills/*/; do
+            [[ -d "$skill_dir" ]] || continue
+            local skill_name
+            skill_name="$(basename "$skill_dir")"
+            sync_symlink "$skill_dir" "$dsh_home/skills/$skill_name"
+        done
+    fi
+
+    # Mark global Git hooks as executable
+    if [[ -d "$XDG_CONFIG_HOME/git/hooks" ]]; then
+        for hook in "$XDG_CONFIG_HOME/git/hooks"/*; do
+            [[ -f "$hook" ]] && chmod +x "$hook"
+        done
+        log_success "Global Git hooks verified as executable."
+    fi
+
+    # core.hooksPath is a fixed literal in config.ini (~/.config/git/hooks):
+    # with a custom XDG_CONFIG_HOME the hooks are installed at $XDG_CONFIG_HOME
+    # instead and git would silently skip them. Warn so the user can fix it.
+    if [[ "$XDG_CONFIG_HOME" != "$HOME/.config" ]]; then
+        log_warn "XDG_CONFIG_HOME is not the default; core.hooksPath in config.ini still points to ~/.config/git/hooks"
+        log_info "Set it explicitly: git config --global core.hooksPath \"$XDG_CONFIG_HOME/git/hooks\""
+    fi
+}
+
 configure_gpg() {
-    log "Configuring GnuPG..."
+    log_step "Securing GnuPG Environment"
+
     local gpg_home="$XDG_DATA_HOME/gnupg"
     local owner="${SUDO_USER:-$(whoami)}"
 
@@ -359,91 +603,244 @@ configure_gpg() {
     chown -R "$owner" "$gpg_home"
     chmod 700 "$gpg_home"
 
-    log "GnuPG permissions secured."
+    local agent_conf="$gpg_home/gpg-agent.conf"
+    if [[ ! -f "$agent_conf" ]]; then
+        local pinentry_program=""
+        for candidate in pinentry-mac pinentry-curses pinentry; do
+            if command_exists "$candidate"; then
+                pinentry_program="$(command -v "$candidate")"
+                break
+            fi
+        done
+
+        if [[ -n "$pinentry_program" ]]; then
+            cat <<EOF > "$agent_conf"
+# Managed by dotfiles install.sh
+# Pinentry program for GPG passphrase prompts (TUI/CLI friendly)
+pinentry-program $pinentry_program
+EOF
+            chown "$owner" "$agent_conf"
+            log_success "Generated $agent_conf (pinentry: $pinentry_program)"
+
+            if command_exists gpgconf; then
+                gpgconf --kill gpg-agent >/dev/null 2>&1 || true
+                log_info "Reloaded gpg-agent daemon."
+            fi
+        else
+            log_warn "No supported pinentry binary detected. GPG signing in TUI may block."
+        fi
+    else
+        log_info "$agent_conf already exists; retaining existing configuration."
+    fi
 }
 
-# Ensure fd is available as 'fd' even on systems that name it 'fdfind' (Debian/Ubuntu)
 configure_fd_alias() {
-    # If 'fdfind' exists (installed by apt) but 'fd' does not
     if command_exists fdfind && ! command_exists fd; then
-        log "Mapping 'fdfind' to 'fd' in ~/.local/bin..."
+        log_info "Creating compatibility alias 'fd' -> 'fdfind' in ~/.local/bin..."
         ln -sf "$(command -v fdfind)" "$HOME/.local/bin/fd"
     fi
 }
 
-# Create symbolic links for dotfiles, backing up any existing configurations.
-setup_symlinks() {
-    log "Synchronizing Dotfiles..."
+# ==============================================================================
+# 7.5 Login Shell & Bash Version Management
+# ==============================================================================
 
-    local dotfiles_dir
-    dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# macOS ships /bin/bash 3.2 (Apple froze it under GPLv3) while ble.sh
+# recommends Bash >= 4.0 — auto-complete and menu-filter are 4.0+ features.
+# The installer never replaces /bin/bash: Homebrew's bash installs in parallel
+# at $(brew --prefix)/bin/bash. The login shell is switched automatically ONLY
+# when it is the system /bin/bash; zsh/fish/other login shells are never
+# touched — those users get a one-time manual hint in the final message
+# instead (BASH_SHELL_GUIDANCE). Everything here stays Bash-3.2-compatible on
+# purpose: this installer itself may be running under /bin/bash 3.2 on macOS.
 
-    local backup_dir="$HOME/.dotfiles_backup_$(date +%Y%m%d_%H%M%S)"
-    mkdir -p "$backup_dir"
+get_login_shell() {
+    local user="${SUDO_USER:-$(whoami)}"
 
-    # "Source_Rel_Path:Dest_Abs_Path"
-    local links=(
-        ".bash_profile:$HOME/.bash_profile"
-        ".bashrc:$HOME/.bashrc"
-        "config/starship.toml:$XDG_CONFIG_HOME/starship.toml"
-        "config/bash:$XDG_CONFIG_HOME/bash"
-        "config/git:$XDG_CONFIG_HOME/git"
-    )
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        dscl . -read "/Users/$user" UserShell 2>/dev/null | awk '{print $2}'
+    else
+        getent passwd "$user" 2>/dev/null | cut -d: -f7
+    fi
+}
 
-    for link in "${links[@]}"; do
-        local src="${link%%:*}"
-        local dest="${link#*:}"
-        local full_src="$dotfiles_dir/$src"
+# macOS only: one-time login-shell switch with verification. The /etc/shells
+# append may be silently rejected (SIP/permissions), so verify with grep
+# before chsh, then re-verify the result via dscl. Failures degrade to a
+# manual instruction set in BASH_SHELL_GUIDANCE instead of exiting.
+switch_login_shell() {
+    local target="$1" current="$2" user="${SUDO_USER:-$(whoami)}" verify
 
-        # Ensure parent dir exists
-        mkdir -p "$(dirname "$dest")"
+    log_info "Switching login shell $current -> $target ..."
+    if ! grep -qxF "$target" /etc/shells 2>/dev/null; then
+        sudo sh -c "printf '%s\n' '$target' >> /etc/shells" 2>/dev/null || true
+    fi
+    if ! grep -qxF "$target" /etc/shells 2>/dev/null; then
+        log_warn "Could not add $target to /etc/shells (permissions/SIP may block it)."
+        BASH_SHELL_GUIDANCE="Add '$target' to /etc/shells and switch (one-time): sudo sh -c 'echo \"$target\" >> /etc/shells' && sudo chsh -s \"$target\" \"$user\""
+        return 1
+    fi
 
-        # Backup Logic:
-        # 1. If dest exists and is NOT a symlink -> Backup
-        # 2. If dest is a directory (even if empty) and not a symlink -> Backup
-        if [ -e "$dest" ] && [ ! -L "$dest" ]; then
-            log "Backing up existing: $dest"
-            mv "$dest" "$backup_dir/"
+    if sudo chsh -s "$target" "$user" 2>/dev/null; then
+        verify="$(dscl . -read "/Users/$user" UserShell 2>/dev/null | awk '{print $2}')"
+        if [[ "$verify" == "$target" ]]; then
+            log_success "Login shell switched to $target (takes effect in new terminal windows)."
+            BASH_SHELL_GUIDANCE=""
+        else
+            log_warn "chsh reported success but the shell is still '${verify:-unknown}'."
+            BASH_SHELL_GUIDANCE="Finish the shell switch manually (one-time): sudo chsh -s \"$target\" \"$user\", then open a new terminal."
+        fi
+    else
+        log_warn "chsh failed (sudo prompt interrupted or unavailable)."
+        BASH_SHELL_GUIDANCE="Switch manually (one-time): sudo sh -c 'echo \"$target\" >> /etc/shells' && sudo chsh -s \"$target\" \"$user\", then open a new terminal."
+        return 1
+    fi
+}
+
+ensure_bash_shell() {
+    local login_shell brew_bash="" brew_major bash_path
+
+    BASH_SHELL_GUIDANCE=""
+    login_shell="$(get_login_shell)"
+    [[ -z "$login_shell" ]] && login_shell="${SHELL:-}"
+
+    # --- macOS + Homebrew: make sure the current Homebrew bash is present ---
+    if [[ "$(uname -s)" == "Darwin" && "$PM_STRATEGY" == "brew" ]]; then
+        brew_bash="$(brew --prefix)/bin/bash"
+
+        # The installer runs with the user's interactive bash; if that is
+        # still the ancient 3.2, install Homebrew bash (idempotent).
+        if [[ ${BASH_VERSINFO[0]} -lt 4 ]] && [[ "$login_shell" != "$brew_bash" ]]; then
+            log_step "Upgrading Bash for ble.sh (system bash is 3.2; ble.sh recommends >= 4.0)"
+            "${PM_INSTALL_CMD[@]}" bash
         fi
 
-        # Link Creation
-        # ln -sf will force overwrite if it's a file or symlink.
-        # But if dest is a directory, 'ln -sf src dest' creates 'dest/src', which is wrong.
-        # The backup logic above should handle the directory case, but we double check.
-        if [ -d "$dest" ] && [ ! -L "$dest" ]; then
-             error "Destination $dest is a directory and failed to backup. Skipping."
-             continue
+        if [[ -x "$brew_bash" ]]; then
+            brew_major="$("$brew_bash" -c 'echo ${BASH_VERSINFO[0]}')"
+            if [[ "$brew_major" -ge 4 ]]; then
+                log_success "Homebrew Bash $("$brew_bash" -c 'echo ${BASH_VERSION}') installed at $brew_bash"
+            else
+                brew_bash=""
+                log_warn "Homebrew Bash at $brew_bash is below 4.0; ble.sh auto-complete/menu-filter will degrade."
+            fi
+        else
+            brew_bash=""
+            log_warn "Homebrew Bash not found ('brew install bash' may have failed)."
         fi
+    fi
 
-        log "Linking: $dest -> $src"
-        ln -sf "$full_src" "$dest"
+    # --- Cross-platform login-shell classification for the final message ---
+    case "$login_shell" in
+        *bash*)
+            if [[ -n "$brew_bash" && "$login_shell" != "$brew_bash" ]]; then
+                # macOS + login shell is the system /bin/bash (3.2): auto-switch.
+                switch_login_shell "$brew_bash" "$login_shell"
+            elif [[ "$(uname -s)" == "Darwin" && -z "$brew_bash" ]]; then
+                # macOS + /bin/bash but brew bash unavailable: loud manual fix.
+                BASH_SHELL_GUIDANCE="Homebrew bash could not be installed/verified; ble.sh features degrade on Bash 3.2. Fix (one-time): brew install bash && sudo sh -c 'echo \"$(brew --prefix)/bin/bash\" >> /etc/shells' && sudo chsh -s \"$(brew --prefix)/bin/bash\" \"${SUDO_USER:-$(whoami)}\""
+            fi
+            ;;
+        "")
+            BASH_SHELL_GUIDANCE="Could not detect your login shell; this setup only applies under bash. Set your login shell to bash (chsh) before restarting."
+            ;;
+        *)
+            # zsh / fish / sh / other: never touch it, only guide.
+            if [[ -n "$brew_bash" ]]; then
+                BASH_SHELL_GUIDANCE="Your login shell is $login_shell; this setup only activates under bash. Switch (one-time): sudo sh -c 'echo \"$brew_bash\" >> /etc/shells' && sudo chsh -s \"$brew_bash\" \"${SUDO_USER:-$(whoami)}\", then open a new terminal."
+            else
+                bash_path="$(command -v bash)"
+                if [[ -z "$bash_path" ]]; then
+                    BASH_SHELL_GUIDANCE="Bash not found on PATH; this setup requires bash."
+                elif grep -qxF "$bash_path" /etc/shells 2>/dev/null; then
+                    BASH_SHELL_GUIDANCE="Your login shell is $login_shell; this setup only activates under bash. Switch (one-time): sudo chsh -s \"$bash_path\" \"${SUDO_USER:-$(whoami)}\", then open a new terminal."
+                else
+                    BASH_SHELL_GUIDANCE="Your login shell is $login_shell; this setup only activates under bash. Switch (one-time): sudo sh -c 'echo \"$bash_path\" >> /etc/shells' && sudo chsh -s \"$bash_path\" \"${SUDO_USER:-$(whoami)}\", then open a new terminal."
+                fi
+            fi
+            ;;
+    esac
+}
+
+# ==============================================================================
+# 8. Command-Line Interface & Orchestration
+# ==============================================================================
+
+show_help() {
+    cat <<EOF
+Usage: $SCRIPT_NAME [OPTIONS]
+
+Options:
+  --with-git-tui  Install hunk, lazygit, and link their configurations.
+  --with-dsh      Install DeepSeek Harness via pnpm and link skills.
+  -h, --help      Display this help documentation.
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --with-git-tui)
+                FLAG_GIT_TUI=1
+                log_info "Option enabled: Git TUI Review Stack"
+                shift
+                ;;
+            --with-dsh)
+                FLAG_WITH_DSH=1
+                log_info "Option enabled: DeepSeek Harness"
+                shift
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                log_warn "Ignoring unrecognized argument: $1"
+                shift
+                ;;
+        esac
     done
 }
 
-# ==============================================================================
-# Main Execution Flow
-# ==============================================================================
-
 main() {
-    log "Starting Dotfiles Setup ❮❮❮"
+    log_step "Dotfiles Setup Initialized"
 
+    parse_args "$@"
+    init_xdg_env
     detect_environment
-    setup_xdg_dirs
-    install_packages
+    install_base_packages
+    ensure_bash_shell
+    check_git_version
+    install_pnpm
 
-    # Install/Update smart tools with version enforcement
-    # Arguments: verify_and_install_tool <cmd> <package> <min_version> <fallback_func>
-    verify_and_install_tool "fzf" "fzf" "0.60" "install_fzf_manual"
-    verify_and_install_tool "starship" "starship" "1.20.0" "install_starship_manual"
+    # Version Enforcement Verification
+    ensure_tool_version "fzf" "fzf" "0.60" "install_fzf_fallback"
+    ensure_tool_version "starship" "starship" "1.20.0" "install_starship_fallback"
 
-    # Post-installation configurations
+    if [[ "$FLAG_GIT_TUI" -eq 1 ]]; then
+        ensure_tool_version "hunk" "hunk" "0.19.0" "install_hunk_fallback"
+        ensure_tool_version "lazygit" "lazygit" "0.44.0" "install_lazygit_fallback"
+    fi
+
+    if [[ "$FLAG_WITH_DSH" -eq 1 ]]; then
+        install_dsh
+    fi
+
     configure_fd_alias
-
     setup_symlinks
     configure_gpg
 
-    log "Setup Complete! ❮❮❮"
-    log "Please restart your shell or run 'source ~/.bashrc' to apply changes."
+    if [[ "$FLAG_GIT_TUI" -eq 0 || "$FLAG_WITH_DSH" -eq 0 ]]; then
+        printf "\n"
+        log_info "Tip: Run with '--with-git-tui' to enable the Lazygit/Hunk stack."
+        log_info "     Run with '--with-dsh' to deploy the DeepSeek Harness ecosystem."
+    fi
+
+    log_step "Dotfiles Setup Completed Successfully"
+    if [[ -n "$BASH_SHELL_GUIDANCE" ]]; then
+        log_info "$BASH_SHELL_GUIDANCE"
+    else
+        log_info "Run 'source ~/.bashrc' or restart your terminal session to apply changes."
+    fi
 }
 
-main
+main "$@"

--- a/skills/git-commit-architect/SKILL.md
+++ b/skills/git-commit-architect/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: git-commit-architect
+description: Audits working-tree diffs, produces Conventional Commit drafts, writes them to .git/AI_COMMIT_MSG, and hands off to the human for review and GPG signing. Use when the user asks to commit changes or review a diff.
+---
+
+# Git Commit Architect
+
+You are the draft-only commit architect in a Human-in-the-Loop Git workflow.
+You prepare everything; the human reviews, edits, and cryptographically signs.
+(PR descriptions are a separate skill: `git-pr-architect`.)
+
+## Hard Rules (non-negotiable)
+
+1. **NEVER execute**: `git commit`, `git push`, `git push -f`, `git reset --hard`,
+   `git branch -D`, `git rebase`, `git merge`, `git cherry-pick`, `git tag`,
+   `gh pr create`. These are the human's exclusive actions.
+2. **Draft-only output**: write the commit message draft to exactly one place:
+   `$(git rev-parse --git-dir)/AI_COMMIT_MSG`. Never write it anywhere else,
+   and never ask the user to copy-paste a message.
+3. **No character-level hard wrapping**: do NOT count characters or force line
+   breaks at 72 columns. Wrapping is deterministic tooling's job: the user's
+   Vim config (`config/vim/vimrc`) rewraps commit-message lines at 72 columns
+   **on save** (`BufWritePre`), so long body lines are fixed automatically
+   while the human reviews. Keep body lines reasonably short (< 72 chars) as
+   a soft habit, but never compute character lengths.
+4. **No hallucination**: describe only changes actually present in the diff.
+   If verification steps are unknown, write `N/A` instead of inventing them.
+5. **Language**: commit messages in professional English; conversational
+   explanations in the user's language.
+
+## Execution Protocol
+
+### Step 1 — Audit the diff
+
+```bash
+git diff --staged    # staged changes first
+git diff             # if nothing is staged, unstaged changes
+git status -sb       # context: branch, untracked files
+```
+
+Read the full diff before writing anything. Do not summarize from memory.
+
+### Step 2 — Generate the message (Conventional Commits)
+
+Header: `<type>(<scope>): <summary in imperative mood, lowercase, <= 50 chars>`
+
+Types: `feat`, `fix`, `refactor`, `docs`, `style`, `perf`, `chore`, `test`.
+
+Body: explain WHAT and WHY (present tense), structural implications, and how
+it was verified. Plain text only — no Markdown inside commit messages.
+
+```text
+<type>(<scope>): <summary>
+
+<what and why, present tense>
+
+Key Changes:
+- <Component>: <description>
+
+Impact:
+- <stability / performance / workflow impact>
+
+Verification:
+- <steps performed | inferred static checks | N/A>
+
+Refs: #<issue or PR number> (omit if none)
+Co-authored-by: <Name> <<Email>> (if applicable)
+```
+
+### Step 3 — Stage the draft buffer
+
+```bash
+GIT_DIR=$(git rev-parse --git-dir)
+cat << 'EOF' > "${GIT_DIR}/AI_COMMIT_MSG"
+<the message>
+EOF
+```
+
+Use a **quoted** heredoc delimiter (`'EOF'`) so nothing inside is expanded.
+The file is per-worktree (git-dir resolves per worktree), so concurrent
+worktrees never collide.
+
+### Step 4 — Hand off to the human
+
+```bash
+echo "[AGENT HAND-OFF] Commit draft staged in .git/AI_COMMIT_MSG. Review it and run 'git commit' — the prepare-commit-msg hook injects the draft into your editor, then your GPG passphrase prompt follows."
+```
+
+## Hunk Integration (interactive review)
+
+When the user has a live Hunk session open in another terminal
+(`hunk diff` / `hunk show`), you may steer it:
+
+```bash
+hunk session list                                     # find live sessions
+hunk session get --repo .                             # confirm the matching session
+hunk session review --repo . --json                   # inspect files/hunks; add --include-patch for raw diff text
+hunk session navigate --repo . --file <path> --hunk <n>   # move the window to the relevant hunk
+hunk session comment add --repo . --file <path> --new-line <n> --summary "<note>"
+```
+
+Notes:
+
+- `--repo .` matches the session by repo root; a single live session
+  auto-resolves without it.
+- The session daemon listens on loopback (`127.0.0.1`). If `hunk session list`
+  reports no sessions while Hunk is visibly running, the agent sandbox is
+  likely blocking loopback — fall back to the Step 4 echo notification and
+  ask the user to review in Hunk manually.
+- For the full live-session workflow (notes, highlights, reloads), load the
+  official skill returned by `hunk skill path` (bundled with hunk) and follow it.
+- The user can also review via lazygit keys: `H` (Hunk TUI, Files panel),
+  `A` (Files panel — commit with AI draft injection) and `F` (safe force
+  push `git pf`; `P` stays bound to lazygit's built-in normal Push) — all
+  from the optional Git TUI toolchain installed by
+  `./install.sh --with-git-tui`.
+
+## References
+
+The repository documents the full workflow (human-facing):
+
+- `docs/github-flow.md` — step-by-step GitHub Flow guide (AI-assisted HITL).
+- `docs/git-guide.md` — configuration reference (aliases, hooks, conventions).
+
+Locate them from the repo root — the skill directory may be symlinked into
+`$DSH_HOME/skills`, so never use relative paths from the skill file:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+```
+
+Read them only when the user asks about workflow details beyond this skill.

--- a/skills/git-pr-architect/SKILL.md
+++ b/skills/git-pr-architect/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: git-pr-architect
+description: Audits a feature branch's diff and writes a GitHub Pull Request description draft (GitHub Flavored Markdown) to .git/AI_PR_BODY for the human to review and publish. Use when the user asks to prepare a pull request or PR description.
+---
+
+# Git PR Architect
+
+You are the draft-only pull-request architect in a Human-in-the-Loop Git
+workflow. You prepare the PR description; the human reviews, edits, and
+publishes it. (Commit messages are a separate skill: `git-commit-architect`.)
+
+## Hard Rules (non-negotiable)
+
+1. **NEVER execute**: `git commit`, `git push`, `gh pr create`, `gh pr merge`,
+   `git merge`, `git rebase`, `git branch -D`. Publishing a PR (or anything
+   that touches the remote) is the human's exclusive action.
+2. **Draft-only output**: write the PR description draft to exactly one place:
+   `$(git rev-parse --git-dir)/AI_PR_BODY`. Never publish it anywhere.
+3. **No hallucination**: describe only changes actually present in the diff.
+   If verification steps are unknown, write `N/A` instead of inventing them.
+4. **Language**: PR content in professional English (GitHub Flavored
+   Markdown); conversational explanations in the user's language.
+5. **Markdown is allowed and expected** in PR descriptions (unlike commit
+   messages). No character-level wrapping constraints.
+
+## Execution Protocol
+
+### Step 1 — Audit the branch
+
+```bash
+git status -sb                         # branch context
+git diff --staged                      # staged changes
+git diff                               # unstaged changes
+git log --oneline origin/main..HEAD    # commits on this branch vs main
+```
+
+Understand what the branch changes and why, relative to `main`.
+
+### Step 2 — Generate the PR description (GFM)
+
+Use this template (mirrors the user's commit/PR convention):
+
+```markdown
+## Summary
+
+<Comprehensive explanation of the changes, the problem being solved, and the
+architectural reasoning. Markdown is permitted.>
+
+## Key Changes
+
+- **`<Component/Scope>`**: <Detailed description of the modification>.
+- **`<Component/Scope>`**: <Detailed description of the modification>.
+
+## Impact
+
+- **<Category (e.g., Performance, Workflow)>**: <Description of how this
+  affects the system or users>.
+
+## Verification
+
+- [ ] **Case 1: <Scenario Name or Static Analysis>**
+    - <Step 1>
+    - <Step 2>
+    - **Expected Result**: <Outcome>
+- [ ] **Case 2: <Scenario Name>**
+    - <Step 1>
+    - **Expected Result**: <Outcome>
+
+## Related Issues
+
+Closes #<Issue Number> (if applicable)
+```
+
+### Step 3 — Stage the draft buffer
+
+```bash
+GIT_DIR=$(git rev-parse --git-dir)
+cat << 'EOF' > "${GIT_DIR}/AI_PR_BODY"
+<the PR description>
+EOF
+```
+
+Use a **quoted** heredoc delimiter (`'EOF'`) so nothing inside is expanded.
+
+### Step 4 — Hand off to the human
+
+```bash
+echo "[AGENT HAND-OFF] PR draft staged in .git/AI_PR_BODY. After pushing your branch, publish it with: gh pr create --body-file .git/AI_PR_BODY   (or paste the content into the GitHub PR form)."
+```
+
+## References
+
+The repository documents the full workflow (human-facing):
+
+- `docs/github-flow.md` — step-by-step GitHub Flow guide (including PR
+  creation and Squash-and-Merge cleanup).
+- `docs/git-guide.md` — configuration reference.
+
+Locate them from the repo root — the skill directory may be symlinked into
+`$DSH_HOME/skills`, so never use relative paths from the skill file:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+```
+
+Read them only when the user asks about workflow details beyond this skill.


### PR DESCRIPTION
## Summary

This PR turns the dotfiles template into a modern AI co-work environment with a Human-in-the-Loop git/GitHub workflow, and ships the review-driven fixes that make the refactor production-grade.

The design is deliberately layered. The **core layer** (always installed) is inert by default: hardened git config and global hooks that do nothing until an AI agent writes a draft. The **optional layer** (`--with-git-tui`, `--with-dsh`) wires in Hunk/lazygit review UIs and DeepSeek Harness with the agent-agnostic skill bundle. Destructive privileges stay with the human: the agent drafts commit messages and PR descriptions; the human reviews, edits, and GPG-signs everything.

## Key Changes

- **`install.sh`**: hybrid version enforcement (package-manager candidates with fallback installers), pnpm 12.0.0-rc.9 standalone with on-demand Node provisioning, `--with-git-tui` / `--with-dsh` flags, XDG hunk install via `HUNK_INSTALL_DIR`, macOS upgrade to Homebrew bash with conditional auto-chsh (only when the login shell is the system `/bin/bash`) and cross-platform login-shell guidance, plus loud warnings for custom `XDG_CONFIG_HOME` and legacy `~/.vimrc`.
- **`config/git/config.ini`**: `help.autocorrect=prompt`, double-lease `pf` alias (`--force-with-lease --force-if-includes`), worktree-aware `bclean`, `hdiff` with plain-diff fallback, relative `includeIf` for the work profile, and an empty-by-default `[user]` block that refuses commits until configured (fail loud, no placeholder identity).
- **`config/git/hooks/`**: global `prepare-commit-msg` AI-draft injection (plain commits only; wrapped to 72 columns at injection via `fold`; `exec`-chained `.local` hook; draft survives editor aborts and GPG failures and is cleared by `post-commit` after success), plus `.local` chaining dispatchers for `pre-commit` / `commit-msg` / `pre-push` / `post-commit`.
- **`config/bash/rc.d/`**: XDG `PNPM_HOME` / `DSH_HOME` exports, pnpm completion generation, and a ble.sh Bash >= 4.0 warning.
- **`config/hunk/`, `config/lazygit/`, `config/vim/`**: hunk config; lazygit keys `H` (Hunk TUI), `A` (AI-draft commit, Files panel only), `F` (safe force push) with built-in P/p preserved; vimrc 72-column rewrap on save (comment lines and the `-v` diff left untouched).
- **`skills/` + `docs/`**: `git-commit-architect` and `git-pr-architect` skills (draft-only hard rules), `docs/github-flow.md` step-by-step guide, `docs/git-guide.md` configuration reference, expanded README (requirements, identity setup, XDG notes).

## Impact

- **Workflow**: agent drafts, human reviews and signs — zero copy-paste; non-blocking by default (no agent, no draft, no behavior change).
- **Robustness**: drafts survive failed commits; per-worktree buffers; deterministic 72-column envelope (wrapped at injection, not by a random editor).
- **Safety**: empty identity and double-lease force push fail loud; hook chaining uses direct `exec` (no shell string interpretation).
- **Compatibility**: installer still runs under Bash 3.2; macOS login shell is switched only from the system `/bin/bash`; custom `XDG_CONFIG_HOME` is warned instead of silently broken.

## Verification

- [x] **Static analysis**: `bash -n` / `sh -n` on installer and all hooks; git config parsing.
- [x] **Hook lifecycle (scratch repo)**: draft kept on editor abort and GPG signing failure; cleared after a successful commit; `-m` bypass; local hook exit code 7 propagated unchanged.
- [x] **Wrap-at-injection**: draft lines <= 72 columns after injection, bullet structure preserved, `#` comment block byte-identical.
- [x] **Push lease semantics**: first push of a new branch succeeds; stale push rejected (`stale info`).
- [x] **includeIf resolution**: relative `work.ini` path resolves against the config file under any `XDG_CONFIG_HOME`.
- [x] **Login-shell state machine**: 8 harness cases (Linux/macOS, bash/zsh, success/failure paths).
- [ ] **macOS on-device**: `chsh` / `dscl` / `/etc/shells` path needs confirmation on a real macOS machine (simulated in the harness here).
- [ ] **shellcheck**: not available in the test environment.

## Related Issues

None — first release of the workflow layer; no open issues.
